### PR TITLE
changing error best practices

### DIFF
--- a/effect-best-practices/references/error-patterns.md
+++ b/effect-best-practices/references/error-patterns.md
@@ -1,17 +1,129 @@
 # Error Patterns
 
+## Schema.TaggedError for All Errors
+
+**Always use `Schema.TaggedError`** for defining errors. This provides:
+
+1. **Serialization** - Errors can be sent over RPC/network
+2. **Type safety** - `_tag` discriminator enables `catchTag`
+3. **Consistent structure** - All errors have predictable shape
+4. **HTTP status mapping** - Via `HttpApiSchema.annotations`
+
+### Backend Error Definitions
+
+Business-logic errors should be explicit and rich in context:
+
+```typescript
+import { Schema } from "effect";
+export class InsufficientBalanceError extends Schema.TaggedError<InsufficientBalanceError>()(
+  "InsufficientBalanceError",
+  {
+    reason: Schema.String,
+    currentBalance: Schema.Number,
+    requiredAmount: Schema.Number,
+    accountId: Schema.String,
+  },
+) {}
+```
+
+When we are wrapping other APIs or libraries, we often dont know exactly what errors they will throw, however we do know what we are trying to achieve, so we wrap them in an error type reflecting our intention with a `cause` field to capture the original error details. Where the cause can be a multitude of reasons, we can use `Schema.Defect` which is designed to capture unknown/unexpected errors while preserving stack traces for logging.
+
+```typescript
+import { Schema } from "effect";
+
+export class DatabaseUpsertError extends Schema.TaggedError<DatabaseUpsertError>()(
+  "DatabaseUpsertError",
+  {
+    reason: Schema.String,
+    cause: Schema.Defect,
+  },
+) {}
+
+export class DatabaseUpsertError extends Schema.TaggedError<DatabaseUpsertError>()(
+  "DatabaseUpsertError",
+  {
+    reason: Schema.String,
+    cause: Schema.Defect,
+  },
+) {}
+```
+
+### Frontend Error Definitions
+
+```typescript
+import { Schema } from "effect";
+import { HttpApiSchema } from "@effect/platform";
+
+export class UserNotFoundError extends Schema.TaggedError<UserNotFoundError>()(
+  "UserNotFoundError",
+  {
+    userMessage: Schema.String,
+    userId: UserId,
+  },
+  HttpApiSchema.annotations({ status: 404 }),
+) {}
+
+export class UserCreateError extends Schema.TaggedError<UserCreateError>()(
+  "UserCreateError",
+  {
+    userMessage: Schema.String,
+    cause: Schema.optional(Schema.String),
+  },
+  HttpApiSchema.annotations({ status: 400 }),
+) {}
+
+export class UnauthorizedError extends Schema.TaggedError<UnauthorizedError>()(
+  "UnauthorizedError",
+  {
+    userMessage: Schema.String,
+  },
+  HttpApiSchema.annotations({ status: 401 }),
+) {}
+
+export class ForbiddenError extends Schema.TaggedError<ForbiddenError>()(
+  "ForbiddenError",
+  {
+    userMessage: Schema.String,
+    requiredPermission: Schema.optional(Schema.String),
+  },
+  HttpApiSchema.annotations({ status: 403 }),
+) {}
+```
+
+## Fields
+
+#### Backend
+
+- `reason : Schema.String` - A human readable description that explains why something went wrong.
+- `cause: Schema.Defect` - Should always be used to wrap nested errors such that `Effect.log` can print stack traces.
+- `userMessage: Schema.optional(Schema.String)` - For frontend/api boundary errors where we want to show the user a specific error message. These can be combined in the backend to create more more detailed user facing erros without leaking internal details.
+- Relevant context fields (IDs, etc.)
+
+> [!CAUTION]
+> `message` — Avoid using this field. When present, `Effect.log` may only print the `message` value and omit other fields and contextual information from the error. This can hide important diagnostics and make debugging much harder.
+
+#### Frontend
+
+Frontend errors should be remapped to at the API boundary to avoid leaking internal details.
+
+- `userMessage : Schema.String`: for frontend/api boundary errors where we want to show the user a specific error message. These can be combined in the backend to create more more detailed user facing erros without leaking internal details.
+- `userCause : Schema.optional(Schema.String)`: optional field to provide additional context about the error for the user.
+- `retryable: Schema.Boolean`
+- Relevant context fields (IDs, etc.) that help us display specific UI or take specific actions in the frontend.
+
 ## Why Explicit Error Types?
 
 Generic errors like `BadRequestError` or `NotFoundError` seem convenient but create problems:
 
-| Generic Error | Problems |
-|--------------|----------|
-| `NotFoundError` | Which resource? How should frontend recover? |
-| `BadRequestError` | What's invalid? Can user fix it? |
-| `UnauthorizedError` | Session expired? Wrong credentials? Missing permission? |
-| `InternalServerError` | Retryable? User action needed? |
+| Generic Error         | Problems                                                |
+| --------------------- | ------------------------------------------------------- |
+| `NotFoundError`       | Which resource? How should frontend recover?            |
+| `BadRequestError`     | What's invalid? Can user fix it?                        |
+| `UnauthorizedError`   | Session expired? Wrong credentials? Missing permission? |
+| `InternalServerError` | Retryable? User action needed?                          |
 
 **Explicit errors enable:**
+
 1. **Specific UI messages** - "Your session expired" vs generic "Unauthorized"
 2. **Targeted recovery** - Refresh token vs show login page
 3. **Better observability** - Group errors by specific type in dashboards
@@ -22,19 +134,19 @@ Generic errors like `BadRequestError` or `NotFoundError` seem convenient but cre
 ```typescript
 // ❌ WRONG - Collapsing to generic HTTP errors
 export class NotFoundError extends Schema.TaggedError<NotFoundError>()(
-    "NotFoundError",
-    { message: Schema.String },
-    HttpApiSchema.annotations({ status: 404 }),
+  "NotFoundError",
+  { userMessage: Schema.String },
+  HttpApiSchema.annotations({ status: 404 }),
 ) {}
 
 // At API boundaries:
 Effect.catchTags({
-    UserNotFoundError: (err) => Effect.fail(new NotFoundError({ message: "Not found" })),
-    ChannelNotFoundError: (err) => Effect.fail(new NotFoundError({ message: "Not found" })),
-    MessageNotFoundError: (err) => Effect.fail(new NotFoundError({ message: "Not found" })),
-})
+  UserNotFoundError: (err) => Effect.fail(new NotFoundError({ userMessage: "Not found" })),
+  ChannelNotFoundError: (err) => Effect.fail(new NotFoundError({ userMessage: "Not found" })),
+  MessageNotFoundError: (err) => Effect.fail(new NotFoundError({ userMessage: "Not found" })),
+});
 
-// Frontend receives: { _tag: "NotFoundError", message: "Not found" }
+// Frontend receives: { _tag: "NotFoundError", userMessage: "Not found" }
 // - Can't show specific message ("User doesn't exist" vs "Channel was deleted")
 // - Can't take specific action (redirect to user search vs channel list)
 // - Debugging is harder (which resource was missing?)
@@ -44,13 +156,13 @@ Effect.catchTags({
 // ✅ CORRECT - Keep explicit errors all the way to frontend
 export class UserNotFoundError extends Schema.TaggedError<UserNotFoundError>()(
     "UserNotFoundError",
-    { userId: UserId, message: Schema.String },
+    { userId: UserId, userMessage: Schema.String },
     HttpApiSchema.annotations({ status: 404 }),
 ) {}
 
 export class ChannelNotFoundError extends Schema.TaggedError<ChannelNotFoundError>()(
     "ChannelNotFoundError",
-    { channelId: ChannelId, message: Schema.String },
+    { channelId: ChannelId, userMessage: Schema.String },
     HttpApiSchema.annotations({ status: 404 }),
 ) {}
 
@@ -64,13 +176,13 @@ Result.builder(result)
 
 ## Error Naming Conventions
 
-| Pattern | Example | Use For |
-|---------|---------|---------|
-| `{Entity}NotFoundError` | `UserNotFoundError`, `ChannelNotFoundError` | Resource lookups |
-| `{Entity}{Action}Error` | `UserCreateError`, `MessageUpdateError` | Mutations that fail |
-| `{Feature}Error` | `SessionExpiredError`, `RateLimitExceededError` | Feature-specific failures |
-| `{Integration}Error` | `WorkOSUserFetchError`, `StripePaymentError` | External service errors |
-| `Invalid{Field}Error` | `InvalidEmailError`, `InvalidPasswordError` | Validation failures |
+| Pattern                 | Example                                         | Use For                   |
+| ----------------------- | ----------------------------------------------- | ------------------------- |
+| `{Entity}NotFoundError` | `UserNotFoundError`, `ChannelNotFoundError`     | Resource lookups          |
+| `{Entity}{Action}Error` | `UserCreateError`, `MessageUpdateError`         | Mutations that fail       |
+| `{Feature}Error`        | `SessionExpiredError`, `RateLimitExceededError` | Feature-specific failures |
+| `{Integration}Error`    | `WorkOSUserFetchError`, `StripePaymentError`    | External service errors   |
+| `Invalid{Field}Error`   | `InvalidEmailError`, `InvalidPasswordError`     | Validation failures       |
 
 ### Rich Error Context
 
@@ -79,160 +191,110 @@ Include context fields that help with debugging and UI handling:
 ```typescript
 // Entity errors → include entity ID
 export class UserNotFoundError extends Schema.TaggedError<UserNotFoundError>()(
-    "UserNotFoundError",
-    {
-        userId: UserId,         // Which user?
-        message: Schema.String,
-    },
-    HttpApiSchema.annotations({ status: 404 }),
+  "UserNotFoundError",
+  {
+    userId: UserId, // Which user?
+    userMessage: Schema.String,
+  },
+  HttpApiSchema.annotations({ status: 404 }),
 ) {}
 
 // Action errors → include input that failed
 export class UserCreateError extends Schema.TaggedError<UserCreateError>()(
-    "UserCreateError",
-    {
-        email: Schema.String,   // What email failed?
-        reason: Schema.String,  // Why? "duplicate", "invalid domain"
-        message: Schema.String,
-    },
-    HttpApiSchema.annotations({ status: 400 }),
+  "UserCreateError",
+  {
+    email: Schema.String, // What email failed?
+    userCause: Schema.String, // Why? "duplicate", "invalid domain"
+    userMessage: Schema.String,
+  },
+  HttpApiSchema.annotations({ status: 400 }),
 ) {}
 
 // Integration errors → include service name and retryable flag
 export class StripePaymentError extends Schema.TaggedError<StripePaymentError>()(
-    "StripePaymentError",
-    {
-        stripeErrorCode: Schema.String,
-        retryable: Schema.Boolean,
-        message: Schema.String,
-    },
-    HttpApiSchema.annotations({ status: 402 }),
+  "StripePaymentError",
+  {
+    stripeErrorCode: Schema.String,
+    retryable: Schema.Boolean,
+    userMessage: Schema.String,
+  },
+  HttpApiSchema.annotations({ status: 402 }),
 ) {}
 
 // Auth errors → include expiry info
 export class SessionExpiredError extends Schema.TaggedError<SessionExpiredError>()(
-    "SessionExpiredError",
-    {
-        sessionId: SessionId,
-        expiredAt: Schema.DateTimeUtc,
-        message: Schema.String,
-    },
-    HttpApiSchema.annotations({ status: 401 }),
+  "SessionExpiredError",
+  {
+    sessionId: SessionId,
+    expiredAt: Schema.DateTimeUtc,
+    userMessage: Schema.String,
+  },
+  HttpApiSchema.annotations({ status: 401 }),
 ) {}
 ```
-
-## Schema.TaggedError for All Errors
-
-**Always use `Schema.TaggedError`** for defining errors. This provides:
-
-1. **Serialization** - Errors can be sent over RPC/network
-2. **Type safety** - `_tag` discriminator enables `catchTag`
-3. **Consistent structure** - All errors have predictable shape
-4. **HTTP status mapping** - Via `HttpApiSchema.annotations`
-
-### Basic Error Definition
-
-```typescript
-import { Schema } from "effect"
-import { HttpApiSchema } from "@effect/platform"
-
-export class UserNotFoundError extends Schema.TaggedError<UserNotFoundError>()(
-    "UserNotFoundError",
-    {
-        userId: UserId,
-        message: Schema.String,
-    },
-    HttpApiSchema.annotations({ status: 404 }),
-) {}
-
-export class UserCreateError extends Schema.TaggedError<UserCreateError>()(
-    "UserCreateError",
-    {
-        message: Schema.String,
-        cause: Schema.optional(Schema.String),
-    },
-    HttpApiSchema.annotations({ status: 400 }),
-) {}
-
-export class UnauthorizedError extends Schema.TaggedError<UnauthorizedError>()(
-    "UnauthorizedError",
-    {
-        message: Schema.String,
-    },
-    HttpApiSchema.annotations({ status: 401 }),
-) {}
-
-export class ForbiddenError extends Schema.TaggedError<ForbiddenError>()(
-    "ForbiddenError",
-    {
-        message: Schema.String,
-        requiredPermission: Schema.optional(Schema.String),
-    },
-    HttpApiSchema.annotations({ status: 403 }),
-) {}
-```
-
-### Required Fields
-
-Every error should have:
-- `message: Schema.String` - Human-readable description
-- Relevant context fields (IDs, etc.)
-- Optional `cause: Schema.optional(Schema.String)` for error chains
 
 ## Error Handling with catchTag/catchTags
 
-**Never use `catchAll` or `mapError`** when you can use `catchTag`/`catchTags`. These preserve type information and enable precise error handling.
+**Never use `catchAll` or `mapError`** when you can use `catchTag`/`catchTags`. These preserve type information and enable precise error handling. Make sure to also keep the original error context by wrapping with `cause` where appropriate.
 
 ### catchTag for Single Error Types
 
 ```typescript
 const findUser = Effect.fn("UserService.findUser")(function* (id: UserId) {
-    return yield* repo.findById(id).pipe(
-        Effect.catchTag("DatabaseError", (err) =>
-            Effect.fail(new UserNotFoundError({
-                userId: id,
-                message: `Database lookup failed: ${err.message}`,
-            }))
-        ),
-    )
-})
+  return yield* repo.findById(id).pipe(
+    Effect.catchTag("DatabaseError", (err) =>
+      Effect.fail(
+        new UserNotFoundError({
+          userId: id,
+          reason: `Database lookup failed`,
+          cause: err,
+        }),
+      ),
+    ),
+  );
+});
 ```
 
 ### catchTags for Multiple Error Types
 
 ```typescript
 const processOrder = Effect.fn("OrderService.processOrder")(function* (input: OrderInput) {
-    return yield* validateAndProcess(input).pipe(
-        Effect.catchTags({
-            ValidationError: (err) =>
-                Effect.fail(new OrderValidationError({
-                    message: err.message,
-                    field: err.field,
-                })),
-            PaymentError: (err) =>
-                Effect.fail(new OrderPaymentError({
-                    message: `Payment failed: ${err.message}`,
-                    code: err.code,
-                })),
-            InventoryError: (err) =>
-                Effect.fail(new OrderInventoryError({
-                    productId: err.productId,
-                    message: "Insufficient inventory",
-                })),
-        }),
-    )
-})
+  return yield* validateAndProcess(input).pipe(
+    Effect.catchTags({
+      ValidationError: (err) =>
+        Effect.fail(
+          new OrderValidationError({
+            message: err.message,
+            field: err.field,
+          }),
+        ),
+      PaymentError: (err) =>
+        Effect.fail(
+          new OrderPaymentError({
+            message: `Payment failed: ${err.message}`,
+            code: err.code,
+          }),
+        ),
+      InventoryError: (err) =>
+        Effect.fail(
+          new OrderInventoryError({
+            productId: err.productId,
+            message: "Insufficient inventory",
+          }),
+        ),
+    }),
+  );
+});
 ```
 
 ### Why Not catchAll?
 
 ```typescript
 // WRONG - Loses type information
-yield* effect.pipe(
-    Effect.catchAll((err) =>
-        Effect.fail(new InternalServerError({ message: "Something failed" }))
-    )
-)
+yield *
+  effect.pipe(
+    Effect.catchAll((err) => Effect.fail(new InternalServerError({ message: "Something failed" }))),
+  );
 
 // Problems:
 // 1. Can't distinguish error types downstream
@@ -246,34 +308,36 @@ yield* effect.pipe(
 Create reusable error remapping functions for common transformations:
 
 ```typescript
-import { Effect } from "effect"
+import { Effect } from "effect";
 
 export const withRemapDbErrors = <A, E, R>(
-    effect: Effect.Effect<A, E | DatabaseError | ConnectionError, R>,
-    context: { entityType: string; entityId: string }
+  effect: Effect.Effect<A, E | DatabaseError | ConnectionError, R>,
+  context: { entityType: string; entityId: string },
 ): Effect.Effect<A, E | EntityNotFoundError | ServiceUnavailableError, R> =>
-    effect.pipe(
-        Effect.catchTag("DatabaseError", (err) =>
-            Effect.fail(new EntityNotFoundError({
-                entityType: context.entityType,
-                entityId: context.entityId,
-                message: `${context.entityType} not found`,
-            }))
-        ),
-        Effect.catchTag("ConnectionError", (err) =>
-            Effect.fail(new ServiceUnavailableError({
-                message: "Database connection unavailable",
-                cause: err.message,
-            }))
-        ),
-    )
+  effect.pipe(
+    Effect.catchTag("DatabaseError", (err) =>
+      Effect.fail(
+        new EntityNotFoundError({
+          entityType: context.entityType,
+          entityId: context.entityId,
+          message: `${context.entityType} not found`,
+        }),
+      ),
+    ),
+    Effect.catchTag("ConnectionError", (err) =>
+      Effect.fail(
+        new ServiceUnavailableError({
+          message: "Database connection unavailable",
+          cause: err.message,
+        }),
+      ),
+    ),
+  );
 
 // Usage
 const findUser = Effect.fn("UserService.findUser")(function* (id: UserId) {
-    return yield* repo.findById(id).pipe(
-        withRemapDbErrors({ entityType: "User", entityId: id })
-    )
-})
+  return yield* repo.findById(id).pipe(withRemapDbErrors({ entityType: "User", entityId: id }));
+});
 ```
 
 ## Retryable Errors Pattern
@@ -282,56 +346,56 @@ For errors that may be transient, add a `retryable` property:
 
 ```typescript
 export class ServiceUnavailableError extends Schema.TaggedError<ServiceUnavailableError>()(
-    "ServiceUnavailableError",
-    {
-        message: Schema.String,
-        cause: Schema.optional(Schema.String),
-        retryable: Schema.optionalWith(Schema.Boolean, { default: () => true }),
-    },
-    HttpApiSchema.annotations({ status: 503 }),
+  "ServiceUnavailableError",
+  {
+    message: Schema.String,
+    cause: Schema.optional(Schema.String),
+    retryable: Schema.optionalWith(Schema.Boolean, { default: () => true }),
+  },
+  HttpApiSchema.annotations({ status: 503 }),
 ) {}
 
 export class RateLimitError extends Schema.TaggedError<RateLimitError>()(
-    "RateLimitError",
-    {
-        message: Schema.String,
-        retryAfter: Schema.optional(Schema.Number),
-        retryable: Schema.optionalWith(Schema.Boolean, { default: () => true }),
-    },
-    HttpApiSchema.annotations({ status: 429 }),
+  "RateLimitError",
+  {
+    message: Schema.String,
+    retryAfter: Schema.optional(Schema.Number),
+    retryable: Schema.optionalWith(Schema.Boolean, { default: () => true }),
+  },
+  HttpApiSchema.annotations({ status: 429 }),
 ) {}
 
 // Non-retryable error
 export class ValidationError extends Schema.TaggedError<ValidationError>()(
-    "ValidationError",
-    {
-        message: Schema.String,
-        field: Schema.String,
-        retryable: Schema.optionalWith(Schema.Boolean, { default: () => false }),
-    },
-    HttpApiSchema.annotations({ status: 400 }),
+  "ValidationError",
+  {
+    message: Schema.String,
+    field: Schema.String,
+    retryable: Schema.optionalWith(Schema.Boolean, { default: () => false }),
+  },
+  HttpApiSchema.annotations({ status: 400 }),
 ) {}
 ```
 
 ### Retry Based on Error Property
 
 ```typescript
-import { Effect, Schedule } from "effect"
+import { Effect, Schedule } from "effect";
 
 const withRetry = <A, E extends { retryable?: boolean }, R>(
-    effect: Effect.Effect<A, E, R>
+  effect: Effect.Effect<A, E, R>,
 ): Effect.Effect<A, E, R> =>
-    effect.pipe(
-        Effect.retry(
-            Schedule.exponential("100 millis").pipe(
-                Schedule.intersect(Schedule.recurs(3)),
-                Schedule.whileInput((err: E) => err.retryable === true),
-            )
-        ),
-    )
+  effect.pipe(
+    Effect.retry(
+      Schedule.exponential("100 millis").pipe(
+        Schedule.intersect(Schedule.recurs(3)),
+        Schedule.whileInput((err: E) => err.retryable === true),
+      ),
+    ),
+  );
 
 // Usage
-yield* callExternalApi(request).pipe(withRetry)
+yield * callExternalApi(request).pipe(withRetry);
 ```
 
 ## Error Unions for Activities
@@ -340,37 +404,33 @@ When defining workflow activities, use explicit error unions:
 
 ```typescript
 // Activity error type - union of possible errors
-export type GetChannelMembersError =
-    | DatabaseError
-    | ChannelNotFoundError
+export type GetChannelMembersError = DatabaseError | ChannelNotFoundError;
 
-export class DatabaseError extends Schema.TaggedError<DatabaseError>()(
-    "DatabaseError",
-    {
-        message: Schema.String,
-        cause: Schema.optional(Schema.String),
-        retryable: Schema.optionalWith(Schema.Boolean, { default: () => true }),
-    },
-) {}
+export class DatabaseError extends Schema.TaggedError<DatabaseError>()("DatabaseError", {
+  message: Schema.String,
+  cause: Schema.optional(Schema.String),
+  retryable: Schema.optionalWith(Schema.Boolean, { default: () => true }),
+}) {}
 
 export class ChannelNotFoundError extends Schema.TaggedError<ChannelNotFoundError>()(
-    "ChannelNotFoundError",
-    {
-        channelId: ChannelId,
-        message: Schema.String,
-        retryable: Schema.optionalWith(Schema.Boolean, { default: () => false }),
-    },
+  "ChannelNotFoundError",
+  {
+    channelId: ChannelId,
+    message: Schema.String,
+    retryable: Schema.optionalWith(Schema.Boolean, { default: () => false }),
+  },
 ) {}
 
 // In activity definition
-yield* Activity.make({
+yield *
+  Activity.make({
     name: "GetChannelMembers",
     success: ChannelMembersResult,
     error: Schema.Union(DatabaseError, ChannelNotFoundError),
     execute: Effect.gen(function* () {
-        // ...
+      // ...
     }),
-})
+  });
 ```
 
 ## HTTP Status Codes (Without Generic Errors)
@@ -380,50 +440,51 @@ yield* Activity.make({
 ```typescript
 // ✅ CORRECT - Domain errors with HTTP status annotations
 export class UserNotFoundError extends Schema.TaggedError<UserNotFoundError>()(
-    "UserNotFoundError",
-    { userId: UserId, message: Schema.String },
-    HttpApiSchema.annotations({ status: 404 }),  // Status on specific error
+  "UserNotFoundError",
+  { userId: UserId, message: Schema.String },
+  HttpApiSchema.annotations({ status: 404 }), // Status on specific error
 ) {}
 
 export class ChannelNotFoundError extends Schema.TaggedError<ChannelNotFoundError>()(
-    "ChannelNotFoundError",
-    { channelId: ChannelId, message: Schema.String },
-    HttpApiSchema.annotations({ status: 404 }),  // Same status, different error
+  "ChannelNotFoundError",
+  { channelId: ChannelId, message: Schema.String },
+  HttpApiSchema.annotations({ status: 404 }), // Same status, different error
 ) {}
 
 export class SessionExpiredError extends Schema.TaggedError<SessionExpiredError>()(
-    "SessionExpiredError",
-    { sessionId: SessionId, expiredAt: Schema.DateTimeUtc, message: Schema.String },
-    HttpApiSchema.annotations({ status: 401 }),
+  "SessionExpiredError",
+  { sessionId: SessionId, expiredAt: Schema.DateTimeUtc, message: Schema.String },
+  HttpApiSchema.annotations({ status: 401 }),
 ) {}
 
 export class InvalidCredentialsError extends Schema.TaggedError<InvalidCredentialsError>()(
-    "InvalidCredentialsError",
-    { message: Schema.String },
-    HttpApiSchema.annotations({ status: 401 }),  // Same status, different meaning
+  "InvalidCredentialsError",
+  { message: Schema.String },
+  HttpApiSchema.annotations({ status: 401 }), // Same status, different meaning
 ) {}
 ```
 
 ```typescript
 // ❌ WRONG - Generic HTTP error classes
 export class UnauthorizedError extends Schema.TaggedError<UnauthorizedError>()(
-    "UnauthorizedError",
-    { message: Schema.String },
-    HttpApiSchema.annotations({ status: 401 }),
+  "UnauthorizedError",
+  { message: Schema.String },
+  HttpApiSchema.annotations({ status: 401 }),
 ) {}
 
 // Then mapping everything to it - loses critical information!
 Effect.catchTags({
-    SessionExpiredError: (err) => Effect.fail(new UnauthorizedError({ message: "Unauthorized" })),
-    InvalidCredentialsError: (err) => Effect.fail(new UnauthorizedError({ message: "Unauthorized" })),
-    MissingTokenError: (err) => Effect.fail(new UnauthorizedError({ message: "Unauthorized" })),
-})
+  SessionExpiredError: (err) => Effect.fail(new UnauthorizedError({ message: "Unauthorized" })),
+  InvalidCredentialsError: (err) => Effect.fail(new UnauthorizedError({ message: "Unauthorized" })),
+  MissingTokenError: (err) => Effect.fail(new UnauthorizedError({ message: "Unauthorized" })),
+});
 // Frontend can't distinguish: expired session vs wrong password vs missing token
 ```
 
 ### When Generic Errors Are Acceptable
 
 Generic errors are only acceptable for **truly unrecoverable internal errors** where:
+
 - The frontend can only show "Something went wrong"
 - No user action can fix it
 - You're hiding internal details for security
@@ -431,18 +492,20 @@ Generic errors are only acceptable for **truly unrecoverable internal errors** w
 ```typescript
 // Acceptable for unrecoverable errors
 export class InternalServerError extends Schema.TaggedError<InternalServerError>()(
-    "InternalServerError",
-    { message: Schema.String, requestId: Schema.optional(Schema.String) },
-    HttpApiSchema.annotations({ status: 500 }),
+  "InternalServerError",
+  { message: Schema.String, requestId: Schema.optional(Schema.String) },
+  HttpApiSchema.annotations({ status: 500 }),
 ) {}
 
 // Use sparingly - only for truly unexpected errors
 Effect.catchAll((unexpectedError) =>
-    Effect.fail(new InternalServerError({
-        message: "An unexpected error occurred",
-        requestId: context.requestId,
-    }))
-)
+  Effect.fail(
+    new InternalServerError({
+      message: "An unexpected error occurred",
+      requestId: context.requestId,
+    }),
+  ),
+);
 ```
 
 ## Error Logging
@@ -451,35 +514,14 @@ Log errors with structured context:
 
 ```typescript
 const processWithLogging = Effect.fn("OrderService.process")(function* (orderId: OrderId) {
-    return yield* processOrder(orderId).pipe(
-        Effect.tapError((err) =>
-            Effect.log("Order processing failed", {
-                orderId,
-                errorTag: err._tag,
-                errorMessage: err.message,
-            })
-        ),
-    )
-})
-```
-
-Using `Cause.pretty` with the option `renderErrorCause` set to `true` will log both the Effect and Cause stack traces, often desirable when debugging. Make sure that the nested errors use the `cause` and `message` field on `Schema.TaggedError` for this to work properly.
-```typescript
-Effect.catchAllCause((cause) => Effect.log(Cause.pretty(cause, { renderErrorCause: true })))
-```
-
-You should also define a `get message()` on custom errors such that `Cause.pretty` can show the details/other fields of the error.
-```typescript
-class MyError extends Schema.TaggedError<MyError>("MyError")(
-  "MyError",
-  {
-    module: Schema.String,
-    method: Schema.String,
-    description: Schema.String
-  }
-) {
-  override get message(): string {
-    return `${this.module}.${this.method}: ${this.description}`
-  }
-}
+  return yield* processOrder(orderId).pipe(
+    Effect.tapError((err) =>
+      Effect.log("Order processing failed", {
+        orderId,
+        errorTag: err._tag,
+        errorMessage: err.message,
+      }),
+    ),
+  );
+});
 ```


### PR DESCRIPTION
I believe it should be clarified differentiating between frontend and backend errors. As well as clarifying property naming. NOTE: this PR is not complete as I am in the process of figuring out the idiomatic/conventional way to handle errors.

For example, naming a field `cause` or `message` will cause specific behavior in Effect.log:
- `cause` will make it appear as a part of the stack trace.
- `message` will replace the printing of all the fields of the error, with the message itself, potentially causing loss of information when logging.

**I therefore suggest adding the following:**
---
### Naming
Backend-only (internal) errors
Name: *Error (or *RepoError, *ServiceError where appropriate)
Examples:
- DatabaseUpsertError
- StripeCallError
- UserRepoError


Boundary / contract errors (serialized over HTTP/RPC)
Name: *ApiError (or *PublicError)
Examples:
	•	UserNotFoundApiError
	•	InsufficientBalanceApiError
	•	RateLimitExceededApiError


### Fields

#### Backend

- `reason : Schema.String` - A human readable description that explains why something went wrong.
- `cause: Schema.Defect` - Should always be used to wrap nested errors such that `Effect.log` can print stack traces.
- `userMessage: Schema.optional(Schema.String)` - For frontend/api boundary errors where we want to show the user a specific error message. These can be combined in the backend to create more more detailed user facing erros without leaking internal details.
- Relevant context fields (IDs, etc.)

> [!CAUTION]
> `message` — Avoid using this field. When present, `Effect.log` will only print the `message` value and omit other fields and contextual information from the error. This can hide important diagnostics and make debugging much harder.

#### Frontend

Frontend errors should be remapped to at the API boundary to avoid leaking internal details.

- `userMessage : Schema.String`: for frontend/api boundary errors where we want to show the user a specific error message. These can be combined in the backend to create more more detailed user facing erros without leaking internal details.
- `userCause : Schema.optional(Schema.String)`: optional field to provide additional context about the error for the user.
- `retryable: Schema.Boolean`
- Relevant context fields (IDs, etc.) that help us display specific UI or take specific actions in the frontend.

---

And adding that if preferred, one should override the message() function to customize the error logging if they want to avoid i.e spamming the console with error context which can be useful for some reason that isn't debugging.

In addition: the following
```typescript
return yield* validateAndProcess(input).pipe(
    Effect.catchTags({
      PaymentError: (err) =>
        Effect.fail(
          new OrderPaymentError({
            message: `Payment failed: ${err.message}`,
            code: err.code,
          }),
        ),
```
Seems bad practice to me as we might potentially loose the underlying error in a potential stack trace, by not using `cause`. Of course this depends on whether this error is intended to be sent to the frontend or not.

See the following discord thread for examples of output etc: https://discord.com/channels/795981131316985866/1468194668326945054