### PR TITLE
docs: yieldable TaggedErrors and multi-tag catchTag

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Betalyra
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/effect-best-practices/SKILL.md
+++ b/effect-best-practices/SKILL.md
@@ -8,71 +8,122 @@ version: 1.0.0
 
 This skill enforces opinionated, consistent patterns for Effect-TS codebases. These patterns optimize for type safety, testability, observability, and maintainability.
 
+## Core Principles
+
+### Effect Type Signature
+
+```
+Effect<Success, Error, Requirements>
+//      ↑        ↑       ↑
+//      |        |       └── Dependencies (provided via Layers)
+//      |        └── Expected errors (typed, must be handled)
+//      └── Success value
+```
+
+### Data-First Piped Style
+
+**ALWAYS** prefer data-first pipe style for composition:
+
+```typescript
+// ✅ GOOD: Data-first with pipe
+const result = value.pipe(
+  Effect.map((n) => n * 2),
+  Effect.flatMap((n) => processValue(n)),
+  Effect.catchTag("NetworkError", () => Effect.succeed(fallback))
+)
+
+// ❌ BAD: Function-first style
+const result = Effect.catchTag(
+  Effect.flatMap(
+    Effect.map(value, (n) => n * 2),
+    (n) => processValue(n)
+  ),
+  "NetworkError",
+  () => Effect.succeed(fallback)
+)
+```
+
+### "@effect/schema" is deprecated
+
+Don't try to install nor import from "@effect/schema", it is deprecated.
+Instead just import from "effect" package.
+
+```typescript
+// ✅ GOOD
+import { Schema } from "effect"
+
+// ❌ BAD
+import { Schema } from "@effect/schema"
+```
+
 ## Quick Reference: Critical Rules
 
-| Category | DO | DON'T |
-|----------|-----|-------|
-| Services | `Effect.Service` with `accessors: true` | `Context.Tag` for business logic |
-| Dependencies | `dependencies: [Dep.Default]` in service | Manual `Layer.provide` at usage sites |
-| Errors | `Schema.TaggedError` with `message` field | Plain classes or generic Error |
-| Error Specificity | `UserNotFoundError`, `SessionExpiredError` | Generic `NotFoundError`, `BadRequestError` |
-| Error Handling | `catchTag`/`catchTags` | `catchAll` or `mapError` |
-| IDs | `Schema.UUID.pipe(Schema.brand("@App/EntityId"))` | Plain `string` for entity IDs |
-| Functions | `Effect.fn("Service.method")` | Anonymous generators |
-| Logging | `Effect.log` with structured data | `console.log` |
-| Config | `Config.*` with validation | `process.env` directly |
-| Options | `Option.match` with both cases | `Option.getOrThrow` |
-| Nullability | `Option<T>` in domain types | `null`/`undefined` |
-| Atoms | `Atom.make` outside components | Creating atoms inside render |
-| Atom State | `Atom.keepAlive` for global state | Forgetting keepAlive for persistent state |
-| Atom Updates | `useAtomSet` in React components | `Atom.update` imperatively from React |
-| Atom Cleanup | `get.addFinalizer()` for side effects | Missing cleanup for event listeners |
-| Atom Results | `Result.builder` with `onErrorTag` | Ignoring loading/error states |
+| Category          | DO                                                      | DON'T                                      |
+| ----------------- | ------------------------------------------------------- | ------------------------------------------ |
+| Services          | `Effect.Service`                                        | `Context.Tag` for business logic           |
+| Dependencies      | `dependencies: [Dep.Default]` at the top of the service | Manual `Layer.provide` at usage sites      |
+| Errors            | `Schema.TaggedError` with `message` and `cause` fields  | Plain classes or generic Error             |
+| Error Specificity | `UserNotFoundError`, `SessionExpiredError`              | Generic `NotFoundError`, `BadRequestError` |
+| Error Handling    | `catchTag`/`catchTags`                                  | `catchAll` or `mapError`                   |
+| IDs               | `Schema.UUID.pipe(Schema.brand("@App/EntityId"))`       | Plain `string` for entity IDs              |
+| Functions         | `Effect.fn("Service.method")`                           | Anonymous generators                       |
+| Logging           | `Effect.log` with structured data                       | `console.log`                              |
+| Config            | `Config.*` with validation                              | `process.env` directly                     |
+| Options           | `Option.match` with both cases                          | `Option.getOrThrow`                        |
+| Nullability       | `Option<T>` in domain types                             | `null`/`undefined`                         |
+| Atoms             | `Atom.make` outside components                          | Creating atoms inside render               |
+| Atom State        | `Atom.keepAlive` for global state                       | Forgetting keepAlive for persistent state  |
+| Atom Updates      | `useAtomSet` in React components                        | `Atom.update` imperatively from React      |
+| Atom Cleanup      | `get.addFinalizer()` for side effects                   | Missing cleanup for event listeners        |
+| Atom Results      | `Result.builder` with `onErrorTag`                      | Ignoring loading/error states              |
 
 ## Service Definition Pattern
 
 **Always use `Effect.Service`** for business logic services. This provides automatic accessors, built-in `Default` layer, and proper dependency declaration.
 
 ```typescript
-import { Effect } from "effect"
+import { Effect } from "effect";
 
 export class UserService extends Effect.Service<UserService>()("UserService", {
-    accessors: true,
-    dependencies: [UserRepo.Default, CacheService.Default],
-    effect: Effect.gen(function* () {
-        const repo = yield* UserRepo
-        const cache = yield* CacheService
+  accessors: true,
+  dependencies: [UserRepo.Default, CacheService.Default],
+  effect: Effect.gen(function* () {
+    const repo = yield* UserRepo;
+    const cache = yield* CacheService;
 
-        const findById = Effect.fn("UserService.findById")(function* (id: UserId) {
-            const cached = yield* cache.get(id)
-            if (Option.isSome(cached)) return cached.value
+    const findById = Effect.fn("UserService.findById")(function* (id: UserId) {
+      const cached = yield* cache.get(id);
+      if (Option.isSome(cached)) return cached.value;
 
-            const user = yield* repo.findById(id)
-            yield* cache.set(id, user)
-            return user
-        })
+      const user = yield* repo.findById(id);
+      yield* cache.set(id, user);
+      return user;
+    });
 
-        const create = Effect.fn("UserService.create")(function* (data: CreateUserInput) {
-            const user = yield* repo.create(data)
-            yield* Effect.log("User created", { userId: user.id })
-            return user
-        })
+    const create = Effect.fn("UserService.create")(function* (
+      data: CreateUserInput,
+    ) {
+      const user = yield* repo.create(data);
+      yield* Effect.log("User created", { userId: user.id });
+      return user;
+    });
 
-        return { findById, create }
-    }),
+    return { findById, create };
+  }),
 }) {}
 
 // Usage - dependencies are already wired
 const program = Effect.gen(function* () {
-    const user = yield* UserService.findById(userId)
-    return user
-})
+  const user = yield* UserService.findById(userId);
+  return user;
+});
 
 // At app root
-const MainLive = Layer.mergeAll(UserService.Default, OtherService.Default)
+const MainLive = Layer.mergeAll(UserService.Default, OtherService.Default);
 ```
 
 **When `Context.Tag` is acceptable:**
+
 - Infrastructure with runtime injection (Cloudflare KV, worker bindings)
 - Factory patterns where resources are provided externally
 
@@ -83,48 +134,60 @@ See `references/service-patterns.md` for detailed patterns.
 **Always use `Schema.TaggedError`** for errors. This makes them serializable (required for RPC) and provides consistent structure.
 
 ```typescript
-import { Schema } from "effect"
-import { HttpApiSchema } from "@effect/platform"
+import { Schema } from "effect";
+import { HttpApiSchema } from "@effect/platform";
 
 export class UserNotFoundError extends Schema.TaggedError<UserNotFoundError>()(
-    "UserNotFoundError",
-    {
-        userId: UserId,
-        message: Schema.String,
-    },
-    HttpApiSchema.annotations({ status: 404 }),
+  "UserNotFoundError",
+  {
+    userId: UserId,
+    message: Schema.String,
+  },
+  HttpApiSchema.annotations({ status: 404 }),
 ) {}
 
 export class UserCreateError extends Schema.TaggedError<UserCreateError>()(
-    "UserCreateError",
-    {
-        message: Schema.String,
-        cause: Schema.optional(Schema.String),
-    },
-    HttpApiSchema.annotations({ status: 400 }),
+  "UserCreateError",
+  {
+    message: Schema.String,
+    cause: Schema.optional(Schema.String),
+  },
+  HttpApiSchema.annotations({ status: 400 }),
 ) {}
 ```
 
 **Error handling - use `catchTag`/`catchTags`:**
 
 ```typescript
-// CORRECT - preserves type information
-yield* repo.findById(id).pipe(
+// ✅ CORRECT - preserves type information
+yield *
+  repo.findById(id).pipe(
     Effect.catchTag("DatabaseError", (err) =>
-        Effect.fail(new UserNotFoundError({ userId: id, message: "Lookup failed" }))
+      Effect.fail(
+        new UserNotFoundError({ userId: id, message: "Lookup failed" }),
+      ),
     ),
     Effect.catchTag("ConnectionError", (err) =>
-        Effect.fail(new ServiceUnavailableError({ message: "Database unreachable" }))
+      Effect.fail(
+        new ServiceUnavailableError({ message: "Database unreachable" }),
+      ),
     ),
-)
+  );
 
-// CORRECT - multiple tags at once
-yield* effect.pipe(
+// ✅ CORRECT - multiple tags at once
+yield *
+  effect.pipe(
     Effect.catchTags({
-        DatabaseError: (err) => Effect.fail(new UserNotFoundError({ userId: id, message: err.message })),
-        ValidationError: (err) => Effect.fail(new InvalidEmailError({ email: input.email, message: err.message })),
+      DatabaseError: (err) =>
+        Effect.fail(
+          new UserNotFoundError({ userId: id, message: err.message }),
+        ),
+      ValidationError: (err) =>
+        Effect.fail(
+          new InvalidEmailError({ email: input.email, message: err.message }),
+        ),
     }),
-)
+  );
 ```
 
 ### Prefer Explicit Over Generic Errors
@@ -134,39 +197,46 @@ yield* effect.pipe(
 ```typescript
 // WRONG - Generic errors lose information
 export class NotFoundError extends Schema.TaggedError<NotFoundError>()(
-    "NotFoundError",
-    { message: Schema.String },
-    HttpApiSchema.annotations({ status: 404 }),
+  "NotFoundError",
+  { message: Schema.String },
+  HttpApiSchema.annotations({ status: 404 }),
 ) {}
 
 // Then mapping everything to it:
 Effect.catchTags({
-    UserNotFoundError: (err) => Effect.fail(new NotFoundError({ message: "Not found" })),
-    ChannelNotFoundError: (err) => Effect.fail(new NotFoundError({ message: "Not found" })),
-    MessageNotFoundError: (err) => Effect.fail(new NotFoundError({ message: "Not found" })),
-})
+  UserNotFoundError: (err) =>
+    Effect.fail(new NotFoundError({ message: "Not found" })),
+  ChannelNotFoundError: (err) =>
+    Effect.fail(new NotFoundError({ message: "Not found" })),
+  MessageNotFoundError: (err) =>
+    Effect.fail(new NotFoundError({ message: "Not found" })),
+});
 // Frontend gets useless: { _tag: "NotFoundError", message: "Not found" }
 // Which resource? User? Channel? Message? Can't tell!
 ```
 
 ```typescript
-// CORRECT - Explicit domain errors with rich context
+// ✅ CORRECT - Explicit domain errors with rich context
 export class UserNotFoundError extends Schema.TaggedError<UserNotFoundError>()(
-    "UserNotFoundError",
-    { userId: UserId, message: Schema.String },
-    HttpApiSchema.annotations({ status: 404 }),
+  "UserNotFoundError",
+  { userId: UserId, message: Schema.String },
+  HttpApiSchema.annotations({ status: 404 }),
 ) {}
 
 export class ChannelNotFoundError extends Schema.TaggedError<ChannelNotFoundError>()(
-    "ChannelNotFoundError",
-    { channelId: ChannelId, message: Schema.String },
-    HttpApiSchema.annotations({ status: 404 }),
+  "ChannelNotFoundError",
+  { channelId: ChannelId, message: Schema.String },
+  HttpApiSchema.annotations({ status: 404 }),
 ) {}
 
 export class SessionExpiredError extends Schema.TaggedError<SessionExpiredError>()(
-    "SessionExpiredError",
-    { sessionId: SessionId, expiredAt: Schema.DateTimeUtc, message: Schema.String },
-    HttpApiSchema.annotations({ status: 401 }),
+  "SessionExpiredError",
+  {
+    sessionId: SessionId,
+    expiredAt: Schema.DateTimeUtc,
+    message: Schema.String,
+  },
+  HttpApiSchema.annotations({ status: 401 }),
 ) {}
 
 // Frontend can now show specific UI:
@@ -182,35 +252,38 @@ See `references/error-patterns.md` for error remapping and retry patterns.
 **Brand all entity IDs** for type safety across service boundaries:
 
 ```typescript
-import { Schema } from "effect"
+import { Schema } from "effect";
 
 // Entity IDs - always branded
-export const UserId = Schema.UUID.pipe(Schema.brand("@App/UserId"))
-export type UserId = Schema.Schema.Type<typeof UserId>
+export const UserId = Schema.UUID.pipe(Schema.brand("@App/UserId"));
+export type UserId = Schema.Schema.Type<typeof UserId>;
 
-export const OrganizationId = Schema.UUID.pipe(Schema.brand("@App/OrganizationId"))
-export type OrganizationId = Schema.Schema.Type<typeof OrganizationId>
+export const OrganizationId = Schema.UUID.pipe(
+  Schema.brand("@App/OrganizationId"),
+);
+export type OrganizationId = Schema.Schema.Type<typeof OrganizationId>;
 
 // Domain types - use Schema.Struct
 export const User = Schema.Struct({
-    id: UserId,
-    email: Schema.String,
-    name: Schema.String,
-    organizationId: OrganizationId,
-    createdAt: Schema.DateTimeUtc,
-})
-export type User = Schema.Schema.Type<typeof User>
+  id: UserId,
+  email: Schema.String,
+  name: Schema.String,
+  organizationId: OrganizationId,
+  createdAt: Schema.DateTimeUtc,
+});
+export type User = Schema.Schema.Type<typeof User>;
 
 // Input types for mutations
 export const CreateUserInput = Schema.Struct({
-    email: Schema.String.pipe(Schema.pattern(/^[^\s@]+@[^\s@]+\.[^\s@]+$/)),
-    name: Schema.String.pipe(Schema.minLength(1)),
-    organizationId: OrganizationId,
-})
-export type CreateUserInput = Schema.Schema.Type<typeof CreateUserInput>
+  email: Schema.String.pipe(Schema.pattern(/^[^\s@]+@[^\s@]+\.[^\s@]+$/)),
+  name: Schema.String.pipe(Schema.minLength(1)),
+  organizationId: OrganizationId,
+});
+export type CreateUserInput = Schema.Schema.Type<typeof CreateUserInput>;
 ```
 
 **When NOT to brand:**
+
 - Simple strings that don't cross service boundaries (URLs, file paths)
 - Primitive config values
 
@@ -221,22 +294,30 @@ See `references/schema-patterns.md` for transforms and advanced patterns.
 **Always use `Effect.fn`** for service methods. This provides automatic tracing with proper span names:
 
 ```typescript
-// CORRECT - Effect.fn with descriptive name
-const findById = Effect.fn("UserService.findById")(function* (id: UserId) {
-    yield* Effect.annotateCurrentSpan("userId", id)
-    const user = yield* repo.findById(id)
-    return user
-})
+// ❌ BAD - arrow function returning a generic effect
+const findById = (id: UserId) =>
+  Effect.gen(function* () {
+    // ...
+  });
 
-// CORRECT - Effect.fn with multiple parameters
-const transfer = Effect.fn("AccountService.transfer")(
-    function* (fromId: AccountId, toId: AccountId, amount: number) {
-        yield* Effect.annotateCurrentSpan("fromId", fromId)
-        yield* Effect.annotateCurrentSpan("toId", toId)
-        yield* Effect.annotateCurrentSpan("amount", amount)
-        // ...
-    }
-)
+// ✅ CORRECT - Effect.fn with descriptive name
+const findById = Effect.fn("UserService.findById")(function* (id: UserId) {
+  yield* Effect.annotateCurrentSpan("userId", id);
+  const user = yield* repo.findById(id);
+  return user;
+});
+
+// ✅ CORRECT - Effect.fn with multiple parameters
+const transfer = Effect.fn("AccountService.transfer")(function* (
+  fromId: AccountId,
+  toId: AccountId,
+  amount: number,
+) {
+  yield* Effect.annotateCurrentSpan("fromId", fromId);
+  yield* Effect.annotateCurrentSpan("toId", toId);
+  yield* Effect.annotateCurrentSpan("amount", amount);
+  // ...
+});
 ```
 
 ## Layer Composition
@@ -244,29 +325,32 @@ const transfer = Effect.fn("AccountService.transfer")(
 **Declare dependencies in the service**, not at usage sites:
 
 ```typescript
-// CORRECT - dependencies in service definition
-export class OrderService extends Effect.Service<OrderService>()("OrderService", {
+// ✅ CORRECT - dependencies in service definition
+export class OrderService extends Effect.Service<OrderService>()(
+  "OrderService",
+  {
     accessors: true,
     dependencies: [
-        UserService.Default,
-        ProductService.Default,
-        PaymentService.Default,
+      UserService.Default,
+      ProductService.Default,
+      PaymentService.Default,
     ],
     effect: Effect.gen(function* () {
-        const users = yield* UserService
-        const products = yield* ProductService
-        const payments = yield* PaymentService
-        // ...
+      const users = yield* UserService;
+      const products = yield* ProductService;
+      const payments = yield* PaymentService;
+      // ...
     }),
-}) {}
+  },
+) {}
 
 // At app root - simple merge
 const AppLive = Layer.mergeAll(
-    OrderService.Default,
-    // Infrastructure layers (intentionally not in dependencies)
-    DatabaseLive,
-    RedisLive,
-)
+  OrderService.Default,
+  // Infrastructure layers (intentionally not in dependencies)
+  DatabaseLive,
+  RedisLive,
+);
 ```
 
 See `references/layer-patterns.md` for testing layers and config-dependent layers.
@@ -276,17 +360,19 @@ See `references/layer-patterns.md` for testing layers and config-dependent layer
 **Never use `Option.getOrThrow`**. Always handle both cases explicitly:
 
 ```typescript
-// CORRECT - explicit handling
-yield* Option.match(maybeUser, {
-    onNone: () => Effect.fail(new UserNotFoundError({ userId, message: "Not found" })),
+// ✅ CORRECT - explicit handling
+yield *
+  Option.match(maybeUser, {
+    onNone: () =>
+      Effect.fail(new UserNotFoundError({ userId, message: "Not found" })),
     onSome: (user) => Effect.succeed(user),
-})
+  });
 
-// CORRECT - with getOrElse for defaults
-const name = Option.getOrElse(maybeName, () => "Anonymous")
+// ✅ CORRECT - with getOrElse for defaults
+const name = Option.getOrElse(maybeName, () => "Anonymous");
 
-// CORRECT - Option.map for transformations
-const upperName = Option.map(maybeName, (n) => n.toUpperCase())
+// ✅ CORRECT - Option.map for transformations
+const upperName = Option.map(maybeName, (n) => n.toUpperCase());
 ```
 
 ## Effect Atom (Frontend State)
@@ -296,18 +382,18 @@ Effect Atom provides reactive state management for React with Effect integration
 ### Basic Atoms
 
 ```typescript
-import { Atom } from "@effect-atom/atom-react"
+import { Atom } from "@effect-atom/atom-react";
 
 // Define atoms OUTSIDE components
-const countAtom = Atom.make(0)
+const countAtom = Atom.make(0);
 
 // Use keepAlive for global state that should persist
-const userPrefsAtom = Atom.make({ theme: "dark" }).pipe(Atom.keepAlive)
+const userPrefsAtom = Atom.make({ theme: "dark" }).pipe(Atom.keepAlive);
 
 // Atom families for per-entity state
 const modalAtomFamily = Atom.family((type: string) =>
-    Atom.make({ isOpen: false }).pipe(Atom.keepAlive)
-)
+  Atom.make({ isOpen: false }).pipe(Atom.keepAlive),
+);
 ```
 
 ### React Integration
@@ -353,13 +439,13 @@ function UserProfile() {
 
 ```typescript
 const scrollYAtom = Atom.make((get) => {
-    const onScroll = () => get.setSelf(window.scrollY)
+  const onScroll = () => get.setSelf(window.scrollY);
 
-    window.addEventListener("scroll", onScroll)
-    get.addFinalizer(() => window.removeEventListener("scroll", onScroll)) // REQUIRED
+  window.addEventListener("scroll", onScroll);
+  get.addFinalizer(() => window.removeEventListener("scroll", onScroll)); // REQUIRED
 
-    return window.scrollY
-}).pipe(Atom.keepAlive)
+  return window.scrollY;
+}).pipe(Atom.keepAlive);
 ```
 
 See `references/effect-atom-patterns.md` for complete patterns including families, localStorage, and anti-patterns.
@@ -367,6 +453,7 @@ See `references/effect-atom-patterns.md` for complete patterns including familie
 ## RPC & Cluster Patterns
 
 For RPC contracts and cluster workflows, see:
+
 - `references/rpc-cluster-patterns.md` - RpcGroup, Workflow.make, Activity patterns
 
 ## Anti-Patterns (Forbidden)
@@ -375,24 +462,25 @@ These patterns are **never acceptable**:
 
 ```typescript
 // FORBIDDEN - runSync/runPromise inside services
-const result = Effect.runSync(someEffect) // Never do this
+const result = Effect.runSync(someEffect); // Never do this
 
 // FORBIDDEN - throw inside Effect.gen
-yield* Effect.gen(function* () {
-    if (bad) throw new Error("No!") // Use Effect.fail instead
-})
+yield *
+  Effect.gen(function* () {
+    if (bad) throw new Error("No!"); // Use Effect.fail instead
+  });
 
 // FORBIDDEN - catchAll losing type info
-yield* effect.pipe(Effect.catchAll(() => Effect.fail(new GenericError())))
+yield * effect.pipe(Effect.catchAll(() => Effect.fail(new GenericError())));
 
 // FORBIDDEN - console.log
-console.log("debug") // Use Effect.log
+console.log("debug"); // Use Effect.log
 
 // FORBIDDEN - process.env directly
-const key = process.env.API_KEY // Use Config.string("API_KEY")
+const key = process.env.API_KEY; // Use Config.string("API_KEY")
 
 // FORBIDDEN - null/undefined in domain types
-type User = { name: string | null } // Use Option<string>
+type User = { name: string | null }; // Use Option<string>
 ```
 
 See `references/anti-patterns.md` for the complete list with rationale.
@@ -401,20 +489,20 @@ See `references/anti-patterns.md` for the complete list with rationale.
 
 ```typescript
 // Structured logging
-yield* Effect.log("Processing order", { orderId, userId, amount })
+yield * Effect.log("Processing order", { orderId, userId, amount });
 
 // Metrics
-const orderCounter = Metric.counter("orders_processed")
-yield* Metric.increment(orderCounter)
+const orderCounter = Metric.counter("orders_processed");
+yield * Metric.increment(orderCounter);
 
 // Config with validation
 const config = Config.all({
-    port: Config.integer("PORT").pipe(Config.withDefault(3000)),
-    apiKey: Config.secret("API_KEY"),
-    maxRetries: Config.integer("MAX_RETRIES").pipe(
-        Config.validate({ message: "Must be positive", validation: (n) => n > 0 })
-    ),
-})
+  port: Config.integer("PORT").pipe(Config.withDefault(3000)),
+  apiKey: Config.redacted("API_KEY"),
+  maxRetries: Config.integer("MAX_RETRIES").pipe(
+    Config.validate({ message: "Must be positive", validation: (n) => n > 0 }),
+  ),
+});
 ```
 
 See `references/observability-patterns.md` for metrics and tracing patterns.

--- a/effect-best-practices/SKILL.md
+++ b/effect-best-practices/SKILL.md
@@ -359,8 +359,7 @@ See `references/layer-patterns.md` for testing layers and config-dependent layer
 
 ```typescript
 // ✅ CORRECT - explicit handling
-yield *
-  Option.match(maybeUser, {
+yield* Option.match(maybeUser, {
     onNone: () =>
       Effect.fail(new UserNotFoundError({ userId, message: "Not found" })),
     onSome: (user) => Effect.succeed(user),

--- a/effect-best-practices/SKILL.md
+++ b/effect-best-practices/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: effect-best-practices
 description: Enforces Effect-TS patterns for services, errors, layers, and atoms. Use when writing code with Effect.Service, Schema.TaggedError, Layer composition, or effect-atom React components.
-version: 1.0.0
 ---
 
 # Effect-TS Best Practices
@@ -190,60 +189,13 @@ yield* effect.pipe(
 
 ### Prefer Explicit Over Generic Errors
 
-**Every distinct failure reason deserves its own error type.** Don't collapse multiple failure modes into generic HTTP errors.
+**Every distinct failure reason deserves its own error type.** Don't collapse multiple failure modes into generic HTTP errors like `NotFoundError` or `BadRequestError`.
 
-```typescript
-// WRONG - Generic errors lose information
-export class NotFoundError extends Schema.TaggedError<NotFoundError>()(
-  "NotFoundError",
-  { message: Schema.String },
-  HttpApiSchema.annotations({ status: 404 }),
-) {}
+- `UserNotFoundError` with `userId` → Frontend shows "User doesn't exist"
+- `ChannelNotFoundError` with `channelId` → Frontend shows "Channel was deleted"
+- `SessionExpiredError` with `expiredAt` → Frontend shows "Session expired, please log in"
 
-// Then mapping everything to it:
-Effect.catchTags({
-  UserNotFoundError: (err) =>
-    Effect.fail(new NotFoundError({ message: "Not found" })),
-  ChannelNotFoundError: (err) =>
-    Effect.fail(new NotFoundError({ message: "Not found" })),
-  MessageNotFoundError: (err) =>
-    Effect.fail(new NotFoundError({ message: "Not found" })),
-});
-// Frontend gets useless: { _tag: "NotFoundError", message: "Not found" }
-// Which resource? User? Channel? Message? Can't tell!
-```
-
-```typescript
-// ✅ CORRECT - Explicit domain errors with rich context
-export class UserNotFoundError extends Schema.TaggedError<UserNotFoundError>()(
-  "UserNotFoundError",
-  { userId: UserId, message: Schema.String },
-  HttpApiSchema.annotations({ status: 404 }),
-) {}
-
-export class ChannelNotFoundError extends Schema.TaggedError<ChannelNotFoundError>()(
-  "ChannelNotFoundError",
-  { channelId: ChannelId, message: Schema.String },
-  HttpApiSchema.annotations({ status: 404 }),
-) {}
-
-export class SessionExpiredError extends Schema.TaggedError<SessionExpiredError>()(
-  "SessionExpiredError",
-  {
-    sessionId: SessionId,
-    expiredAt: Schema.DateTimeUtc,
-    message: Schema.String,
-  },
-  HttpApiSchema.annotations({ status: 401 }),
-) {}
-
-// Frontend can now show specific UI:
-// - UserNotFoundError → "User doesn't exist"
-// - ChannelNotFoundError → "Channel was deleted"
-// - SessionExpiredError → "Your session expired. Please log in again."
-```
-
-See `references/error-patterns.md` for error remapping and retry patterns.
+Generic errors lose context and prevent targeted recovery. See `references/error-patterns.md` for complete patterns including error remapping and retry strategies.
 
 ## Schema & Branded Types Pattern
 

--- a/effect-best-practices/SKILL.md
+++ b/effect-best-practices/SKILL.md
@@ -460,10 +460,11 @@ See `references/observability-patterns.md` for metrics and tracing patterns.
 
 For detailed patterns, consult these reference files in the `references/` directory:
 
-- `service-patterns.md` - Service definition, Effect.fn, Context.Tag exceptions
+- `service-patterns.md` - Service definition, Effect.fn, Context.Tag exceptions, capability-based services
 - `error-patterns.md` - Schema.TaggedError, error remapping, retry patterns
 - `schema-patterns.md` - Branded types, transforms, Schema.Class
-- `layer-patterns.md` - Dependency composition, testing layers
+- `layer-patterns.md` - Dependency composition, testing layers, merge vs provide
+- `domain-predicates.md` - Equivalence, Order, typeclass-derived predicates
 - `rpc-cluster-patterns.md` - RpcGroup, Workflow, Activity patterns
 - `effect-atom-patterns.md` - Atom, families, React hooks, Result handling
 - `anti-patterns.md` - Complete list of forbidden patterns

--- a/effect-best-practices/SKILL.md
+++ b/effect-best-practices/SKILL.md
@@ -63,7 +63,7 @@ import { Schema } from "@effect/schema"
 | Dependencies      | `dependencies: [Dep.Default]` at the top of the service | Manual `Layer.provide` at usage sites      |
 | Errors            | `Schema.TaggedError` with `message` and `cause` fields  | Plain classes or generic Error             |
 | Error Specificity | `UserNotFoundError`, `SessionExpiredError`              | Generic `NotFoundError`, `BadRequestError` |
-| Error Handling    | `catchTag`/`catchTags`                                  | `catchAll` or `mapError`                   |
+| Error Handling    | `catchTag` (supports multiple tags) / `catchTags`       | `catchAll` or `mapError`                   |
 | IDs               | `Schema.UUID.pipe(Schema.brand("@App/EntityId"))`       | Plain `string` for entity IDs              |
 | Functions         | `Effect.fn("Service.method")`                           | Anonymous generators                       |
 | Logging           | `Effect.log` with structured data                       | `console.log`                              |
@@ -130,7 +130,7 @@ See `references/service-patterns.md` for detailed patterns.
 
 ## Error Definition Pattern
 
-**Always use `Schema.TaggedError`** for errors. This makes them serializable (required for RPC) and provides consistent structure.
+**Always use `Schema.TaggedError`** for errors. This makes them serializable (required for RPC), provides consistent structure, and makes them **yieldable** — no `Effect.fail()` wrapper needed since `TaggedError` instances implement the `Effect` interface directly.
 
 ```typescript
 import { Schema } from "effect";
@@ -158,31 +158,30 @@ export class UserCreateError extends Schema.TaggedError<UserCreateError>()(
 **Error handling - use `catchTag`/`catchTags`:**
 
 ```typescript
-// ✅ CORRECT - preserves type information
+// ✅ CORRECT - single tag
 yield* repo.findById(id).pipe(
     Effect.catchTag("DatabaseError", (err) =>
-      Effect.fail(
-        new UserNotFoundError({ userId: id, message: "Lookup failed" }),
-      ),
-    ),
-    Effect.catchTag("ConnectionError", (err) =>
-      Effect.fail(
-        new ServiceUnavailableError({ message: "Database unreachable" }),
-      ),
+      new UserNotFoundError({ userId: id, message: "Lookup failed" }),
     ),
   );
 
-// ✅ CORRECT - multiple tags at once
+// ✅ CORRECT - multiple tags, same handler (catchTag accepts variadic tags)
+yield* effect.pipe(
+    Effect.catchTag(
+      "TokenExpiredError",
+      "TokenInvalidError",
+      "MissingTokenError",
+      () => new AuthError({ message: "Authentication failed" }),
+    ),
+  );
+
+// ✅ CORRECT - multiple tags, different handlers (use catchTags)
 yield* effect.pipe(
     Effect.catchTags({
       DatabaseError: (err) =>
-        Effect.fail(
-          new UserNotFoundError({ userId: id, message: err.message }),
-        ),
+        new UserNotFoundError({ userId: id, message: err.message }),
       ValidationError: (err) =>
-        Effect.fail(
-          new InvalidEmailError({ email: input.email, message: err.message }),
-        ),
+        new InvalidEmailError({ email: input.email, message: err.message }),
     }),
   );
 ```
@@ -312,8 +311,7 @@ See `references/layer-patterns.md` for testing layers and config-dependent layer
 ```typescript
 // ✅ CORRECT - explicit handling
 yield* Option.match(maybeUser, {
-    onNone: () =>
-      Effect.fail(new UserNotFoundError({ userId, message: "Not found" })),
+    onNone: () => new UserNotFoundError({ userId, message: "Not found" }),
     onSome: (user) => Effect.succeed(user),
   });
 

--- a/effect-best-practices/SKILL.md
+++ b/effect-best-practices/SKILL.md
@@ -519,3 +519,4 @@ For detailed patterns, consult these reference files in the `references/` direct
 - `effect-atom-patterns.md` - Atom, families, React hooks, Result handling
 - `anti-patterns.md` - Complete list of forbidden patterns
 - `observability-patterns.md` - Logging, metrics, config patterns
+- `effect-test-patterns.md` - Testing patterns for effect based applications

--- a/effect-best-practices/SKILL.md
+++ b/effect-best-practices/SKILL.md
@@ -160,8 +160,7 @@ export class UserCreateError extends Schema.TaggedError<UserCreateError>()(
 
 ```typescript
 // ✅ CORRECT - preserves type information
-yield *
-  repo.findById(id).pipe(
+yield* repo.findById(id).pipe(
     Effect.catchTag("DatabaseError", (err) =>
       Effect.fail(
         new UserNotFoundError({ userId: id, message: "Lookup failed" }),
@@ -175,8 +174,7 @@ yield *
   );
 
 // ✅ CORRECT - multiple tags at once
-yield *
-  effect.pipe(
+yield* effect.pipe(
     Effect.catchTags({
       DatabaseError: (err) =>
         Effect.fail(

--- a/effect-best-practices/references/anti-patterns.md
+++ b/effect-best-practices/references/anti-patterns.md
@@ -159,7 +159,7 @@ const port = parseInt(process.env.PORT || "3000")
 
 ```typescript
 const config = yield* Config.all({
-    apiKey: Config.secret("API_KEY"),
+    apiKey: Config.redacted("API_KEY"),
     port: Config.integer("PORT").pipe(Config.withDefault(3000)),
 })
 ```

--- a/effect-best-practices/references/anti-patterns.md
+++ b/effect-best-practices/references/anti-patterns.md
@@ -1,5 +1,24 @@
 # Anti-Patterns (Forbidden)
 
+## Table of Contents
+
+- [Effect.runSync/runPromise Inside Services](#forbidden-effectrunsyncrunpromise-inside-services)
+- [throw Inside Effect.gen](#forbidden-throw-inside-effectgen)
+- [catchAll Losing Type Information](#forbidden-catchall-losing-type-information)
+- [any/unknown Casts](#forbidden-anyunknown-casts)
+- [Promise in Service Signatures](#forbidden-promise-in-service-signatures)
+- [console.log](#forbidden-consolelog)
+- [process.env Directly](#forbidden-processenv-directly)
+- [null/undefined in Domain Types](#forbidden-nullundefined-in-domain-types)
+- [Option.getOrThrow](#forbidden-optiongetorthrow)
+- [Context.Tag for Business Services](#forbidden-contexttag-for-business-services)
+- [Ignoring Errors with orDie](#forbidden-ignoring-errors-with-ordie)
+- [mapError Instead of catchTag](#forbidden-maperror-instead-of-catchtag)
+- [Mixing Effect and Promise Chains](#forbidden-mixing-effect-and-promise-chains)
+- [Mutable State Without Ref](#forbidden-mutable-state-without-ref)
+- [Using Date.now() or new Date() Directly](#forbidden-using-datenow-or-new-date-directly)
+- [Deprecated `_` Adaptor in Effect.gen](#forbidden-deprecated-_-adaptor-in-effectgen)
+
 These patterns are **never acceptable** in Effect-TS code. Each is listed with rationale and the correct alternative.
 
 ## FORBIDDEN: Effect.runSync/runPromise Inside Services

--- a/effect-best-practices/references/anti-patterns.md
+++ b/effect-best-practices/references/anti-patterns.md
@@ -21,6 +21,7 @@ export class UserService extends Effect.Service<UserService>()("UserService", {
 **Why:** Breaks Effect's composition model, loses error handling, can't be tested, loses tracing.
 
 **Correct:**
+
 ```typescript
 const findById = Effect.fn("UserService.findById")(function* (id: UserId) {
     return yield* repo.findById(id)
@@ -43,6 +44,7 @@ yield* Effect.gen(function* () {
 **Why:** Throws bypass Effect's error channel, can't be caught with `catchTag`, breaks type safety.
 
 **Correct:**
+
 ```typescript
 yield* Effect.gen(function* () {
     const user = yield* repo.findById(id)
@@ -67,6 +69,7 @@ yield* someEffect.pipe(
 **Why:** Loses specific error information, makes debugging harder, prevents specific error handling downstream.
 
 **Correct:**
+
 ```typescript
 yield* someEffect.pipe(
     Effect.catchTags({
@@ -87,6 +90,7 @@ const result = (await fetch(url)) as unknown as MyType
 **Why:** Completely bypasses type safety, can cause runtime errors, loses Effect's type guarantees.
 
 **Correct:**
+
 ```typescript
 // Use Schema for parsing unknown data
 const result = yield* Schema.decodeUnknown(MyType)(someValue)
@@ -115,6 +119,7 @@ export class UserService extends Effect.Service<UserService>()("UserService", {
 **Why:** Loses Effect's error handling, can't compose with other Effects, loses tracing/metrics.
 
 **Correct:**
+
 ```typescript
 const findById = Effect.fn("UserService.findById")(
     function* (id: UserId): Effect.Effect<User, UserNotFoundError> {
@@ -134,6 +139,7 @@ console.error("Error:", error)
 **Why:** Not structured, not captured by Effect's logging system, lost in production telemetry.
 
 **Correct:**
+
 ```typescript
 yield* Effect.log("Processing order", { orderId })
 yield* Effect.logError("Operation failed", { error: String(error) })
@@ -150,6 +156,7 @@ const port = parseInt(process.env.PORT || "3000")
 **Why:** No validation, no type safety, fails silently if missing, hard to test.
 
 **Correct:**
+
 ```typescript
 const config = yield* Config.all({
     apiKey: Config.secret("API_KEY"),
@@ -171,6 +178,7 @@ type User = {
 **Why:** Null/undefined handling is error-prone, loses the explicit "absence" semantics.
 
 **Correct:**
+
 ```typescript
 const User = Schema.Struct({
     name: Schema.String,
@@ -190,6 +198,7 @@ const name = pipe(maybeName, Option.getOrThrow)
 **Why:** Throws exceptions, bypasses Effect's error handling, fails at runtime instead of compile time.
 
 **Correct:**
+
 ```typescript
 // Handle both cases explicitly
 yield* Option.match(maybeUser, {
@@ -219,6 +228,7 @@ export class UserService extends Context.Tag("UserService")<
 **Why:** Requires manual layer creation, no built-in accessors, more boilerplate.
 
 **Correct:**
+
 ```typescript
 export class UserService extends Effect.Service<UserService>()("UserService", {
     accessors: true,
@@ -237,11 +247,13 @@ yield* someEffect.pipe(Effect.orDie)
 **Why:** Converts recoverable errors to defects (unrecoverable), loses error information.
 
 **Acceptable exceptions:**
+
 - Truly unrecoverable situations (invalid program state)
 - After exhausting all recovery options
 - In test setup code
 
 **Correct:**
+
 ```typescript
 // Handle errors explicitly
 yield* someEffect.pipe(
@@ -263,6 +275,7 @@ yield* effect.pipe(
 **Why:** Loses error type information, can't discriminate between error types.
 
 **Correct:**
+
 ```typescript
 yield* effect.pipe(
     Effect.catchTag("SpecificError", (err) =>
@@ -286,6 +299,7 @@ const result = await someEffect.pipe(
 **Why:** Loses Effect composition benefits, error handling becomes inconsistent.
 
 **Correct:**
+
 ```typescript
 const program = Effect.gen(function* () {
     const data = yield* someEffect
@@ -306,6 +320,7 @@ const increment = Effect.sync(() => { counter++ })
 **Why:** Race conditions, not testable, not composable, breaks referential transparency.
 
 **Correct:**
+
 ```typescript
 const program = Effect.gen(function* () {
     const counter = yield* Ref.make(0)
@@ -325,11 +340,32 @@ const timestamp = Date.now()
 **Why:** Not testable, introduces non-determinism, hard to mock in tests.
 
 **Correct:**
+
 ```typescript
 import { Clock } from "effect"
 
 const now = yield* Clock.currentTimeMillis
-const date = yield* Clock.currentTimeZone.pipe(
-    Effect.map((tz) => new Date())
-)
+```
+
+## FORBIDDEN: Deprecated `_` Adaptor in Effect.gen
+
+```typescript
+// FORBIDDEN - deprecated adaptor pattern
+Effect.gen(function* (_) {
+    const user = yield* _(repo.findById(id))
+    const posts = yield* _(fetchPosts(user.id))
+    return { user, posts }
+})
+```
+
+**Why:** The `_` adaptor function is deprecated. Modern Effect allows direct `yield*` without an adaptor.
+
+**Correct:**
+
+```typescript
+Effect.gen(function* () {
+    const user = yield* repo.findById(id)
+    const posts = yield* fetchPosts(user.id)
+    return { user, posts }
+})
 ```

--- a/effect-best-practices/references/anti-patterns.md
+++ b/effect-best-practices/references/anti-patterns.md
@@ -68,7 +68,7 @@ yield* Effect.gen(function* () {
 yield* Effect.gen(function* () {
     const user = yield* repo.findById(id)
     if (!user) {
-        return yield* Effect.fail(new UserNotFoundError({ userId: id, message: "Not found" }))
+        return yield* new UserNotFoundError({ userId: id, message: "Not found" })
     }
     return user
 })
@@ -90,11 +90,21 @@ yield* someEffect.pipe(
 **Correct:**
 
 ```typescript
+// Different handlers per tag → use catchTags
 yield* someEffect.pipe(
     Effect.catchTags({
-        DatabaseError: (err) => Effect.fail(new ServiceUnavailableError({ message: err.message })),
-        ValidationError: (err) => Effect.fail(new BadRequestError({ message: err.message })),
+        DatabaseError: (err) => new ServiceUnavailableError({ message: err.message }),
+        ValidationError: (err) => new BadRequestError({ message: err.message }),
     }),
+)
+
+// Same handler for multiple tags → use catchTag with multiple tag strings
+yield* someEffect.pipe(
+    Effect.catchTag(
+        "DatabaseError",
+        "ConnectionError",
+        (err) => new ServiceUnavailableError({ message: err.message }),
+    ),
 )
 ```
 
@@ -221,7 +231,7 @@ const name = pipe(maybeName, Option.getOrThrow)
 ```typescript
 // Handle both cases explicitly
 yield* Option.match(maybeUser, {
-    onNone: () => Effect.fail(new UserNotFoundError({ userId, message: "Not found" })),
+    onNone: () => new UserNotFoundError({ userId, message: "Not found" }),
     onSome: Effect.succeed,
 })
 
@@ -277,7 +287,7 @@ yield* someEffect.pipe(Effect.orDie)
 // Handle errors explicitly
 yield* someEffect.pipe(
     Effect.catchTag("RecoverableError", (err) =>
-        Effect.fail(new DomainError({ message: err.message }))
+        new DomainError({ message: err.message })
     ),
 )
 ```
@@ -298,7 +308,7 @@ yield* effect.pipe(
 ```typescript
 yield* effect.pipe(
     Effect.catchTag("SpecificError", (err) =>
-        Effect.fail(new MappedError({ message: err.message }))
+        new MappedError({ message: err.message })
     ),
 )
 ```

--- a/effect-best-practices/references/domain-predicates.md
+++ b/effect-best-practices/references/domain-predicates.md
@@ -1,0 +1,411 @@
+# Domain Predicates
+
+## Table of Contents
+
+- [Equality with Schema.Data](#equality-with-schemadata)
+- [Equivalence from Schema](#equivalence-from-schema)
+- [Field-Based Equivalence](#field-based-equivalence)
+- [Combining Equivalences](#combining-equivalences)
+- [Order Instances](#order-instances)
+- [Combining Orders](#combining-orders)
+- [Usage Examples](#usage-examples)
+
+Generate complete sets of predicates and Order instances for domain types, derived from typeclass implementations.
+
+## Equality with Schema.Data
+
+When using schemas, leverage `Schema.Data` for automatic structural equality:
+
+```typescript
+import { Schema, Equal } from "effect"
+
+export const Task = Schema.TaggedStruct("pending", {
+  id: Schema.String,
+  createdAt: Schema.DateTimeUtcFromSelf,
+}).pipe(Schema.Data) // Implements Equal.Symbol automatically
+
+// Usage: Automatic structural equality
+const task1 = makeTask({ id: "123", createdAt: now })
+const task2 = makeTask({ id: "123", createdAt: now })
+
+Equal.equals(task1, task2) // true - structural equality
+```
+
+## Equivalence from Schema
+
+When you need an `Equivalence` instance (for use with combinators), derive it from the schema:
+
+```typescript
+import * as Equivalence from "effect/Equivalence"
+
+// Derive from schema (structural equality)
+export const Equivalence = Schema.equivalence(Task)
+
+// Usage with combinators
+const uniqueTasks = Array.dedupeWith(tasks, Equivalence)
+```
+
+## Field-Based Equivalence
+
+Compare by specific fields using `Equivalence.mapInput`:
+
+```typescript
+import * as Equivalence from "effect/Equivalence"
+
+/**
+ * Compare tasks by ID only.
+ *
+ * @category Equivalence
+ * @since 0.1.0
+ * @example
+ * import * as Task from "@/schemas/Task"
+ * import * as Array from "effect/Array"
+ *
+ * const uniqueById = Array.dedupeWith(tasks, Task.EquivalenceById)
+ */
+export const EquivalenceById = Equivalence.mapInput(
+  Equivalence.string,
+  (task: Task) => task.id
+)
+
+/**
+ * Compare by status tag.
+ *
+ * @category Equivalence
+ * @since 0.1.0
+ */
+export const EquivalenceByTag = Equivalence.mapInput(
+  Equivalence.string,
+  (task: Task) => task._tag
+)
+
+/**
+ * Compare by creation date.
+ *
+ * @category Equivalence
+ * @since 0.1.0
+ */
+export const EquivalenceByCreatedAt = Equivalence.mapInput(
+  DateTime.Equivalence,
+  (task: Task) => task.createdAt
+)
+```
+
+**Key Pattern: Equivalence.mapInput**
+
+- Signature: `Equivalence.mapInput(baseEquivalence, (value) => extractField)`
+- Compose from simpler equivalences
+- Map domain type to comparable value
+- Dual API: data-first and data-last
+
+## Combining Equivalences
+
+Use `Equivalence.combine` for multi-field equality:
+
+```typescript
+import * as Equivalence from "effect/Equivalence"
+
+/**
+ * Compare by tag first, then by ID.
+ *
+ * Both must match for equivalence.
+ *
+ * @category Equivalence
+ * @since 0.1.0
+ * @example
+ * import * as Task from "@/schemas/Task"
+ *
+ * const areSame = Task.EquivalenceByTagAndId(task1, task2)
+ */
+export const EquivalenceByTagAndId = Equivalence.combine(
+  EquivalenceByTag,
+  EquivalenceById
+)
+
+/**
+ * Compare by multiple criteria for exact equality.
+ *
+ * @category Equivalence
+ * @since 0.1.0
+ */
+export const EquivalenceComplete = Equivalence.combine(
+  EquivalenceByTag,
+  EquivalenceById,
+  EquivalenceByCreatedAt
+)
+```
+
+**Key Pattern: Equivalence.combine**
+
+- Combines multiple equivalences
+- All must match for equivalence (AND logic)
+- Order doesn't matter (unlike Order.combine)
+
+## Order Instances
+
+Compose orders from simpler base orders using `Order.mapInput`:
+
+```typescript
+import * as Order from "effect/Order"
+import * as DateTime from "effect/DateTime"
+import * as String from "effect/String"
+
+/**
+ * Order by ID using Order.mapInput.
+ *
+ * @category Orders
+ * @since 0.1.0
+ * @example
+ * import * as Task from "@/schemas/Task"
+ * import * as Array from "effect/Array"
+ *
+ * const sorted = Array.sort(tasks, Task.OrderById)
+ */
+export const OrderById: Order.Order<Task> =
+  Order.mapInput(Order.string, (task) => task.id)
+
+/**
+ * Order by creation date.
+ *
+ * @category Orders
+ * @since 0.1.0
+ */
+export const OrderByCreatedAt: Order.Order<Task> =
+  Order.mapInput(DateTime.Order, (task) => task.createdAt)
+
+/**
+ * Order by status tag.
+ *
+ * @category Orders
+ * @since 0.1.0
+ */
+export const OrderByTag: Order.Order<Task> =
+  Order.mapInput(Order.string, (task) => task._tag)
+
+/**
+ * Order by priority (domain-specific logic).
+ *
+ * @category Orders
+ * @since 0.1.0
+ */
+export const OrderByPriority: Order.Order<Task> =
+  Order.mapInput(Order.number, (task) => {
+    const priorities = { pending: 0, active: 1, completed: 2 }
+    return priorities[task._tag]
+  })
+```
+
+**Key Pattern: Order.mapInput**
+
+- Signature: `Order.mapInput(baseOrder, (value) => extractField)`
+- Compose from existing orders (Order.string, Order.number, DateTime.Order, etc.)
+- Map domain type to comparable value
+- Dual API: data-first and data-last
+
+## Combining Orders
+
+Use `Order.combine` for multi-criteria sorting:
+
+```typescript
+import * as Order from "effect/Order"
+
+/**
+ * Sort by priority first, then by creation date.
+ *
+ * @category Orders
+ * @since 0.1.0
+ * @example
+ * import * as Task from "@/schemas/Task"
+ * import * as Array from "effect/Array"
+ *
+ * // High priority tasks first, then by oldest
+ * const sorted = Array.sort(tasks, Task.OrderByPriorityThenDate)
+ */
+export const OrderByPriorityThenDate: Order.Order<Task> = Order.combine(
+  OrderByPriority,
+  OrderByCreatedAt
+)
+
+/**
+ * Sort by tag, then ID, then creation date.
+ *
+ * @category Orders
+ * @since 0.1.0
+ */
+export const OrderComplex: Order.Order<Task> = Order.combine(
+  OrderByTag,
+  OrderById,
+  OrderByCreatedAt
+)
+```
+
+**Key Pattern: Order.combine**
+
+- Combines multiple orders for multi-criteria sorting
+- First order takes precedence, then second, etc.
+- Order matters (unlike Equivalence.combine)
+- Returns combined order that can be used with Array.sort
+
+## Usage Examples
+
+### Equality Examples
+
+```typescript
+import { Equal } from "effect"
+import * as Task from "@/schemas/Task"
+import * as Array from "effect/Array"
+
+// Structural equality (automatic from Schema.Data)
+const areSame = Equal.equals(task1, task2)
+
+// Deduplicate by ID only
+const uniqueById = Array.dedupeWith(tasks, Task.EquivalenceById)
+
+// Deduplicate by tag and ID
+const uniqueByTagAndId = Array.dedupeWith(tasks, Task.EquivalenceByTagAndId)
+
+// Find if array contains equivalent task
+const hasTask = Array.containsWith(tasks, Task.EquivalenceById)(searchTask)
+```
+
+### Sorting Examples
+
+```typescript
+import * as Array from "effect/Array"
+import * as Order from "effect/Order"
+import { pipe } from "effect/Function"
+
+// Simple sort by single field
+const sortedById = Array.sort(tasks, Task.OrderById)
+
+// Multi-criteria sort
+const sortedComplex = Array.sort(
+  tasks,
+  Order.combine(
+    Task.OrderByPriority,
+    Task.OrderByCreatedAt
+  )
+)
+
+// Sort with filter
+const sortedFiltered = pipe(
+  tasks,
+  Array.filter(Task.isPending),
+  Array.sort(Task.OrderByCreatedAt)
+)
+```
+
+### Complex Filtering
+
+Combine predicates for sophisticated queries:
+
+```typescript
+import { pipe } from "effect/Function"
+import * as Array from "effect/Array"
+
+// Find long appointments this week
+const longThisWeek = pipe(
+  appointments,
+  Array.filter(Appointment.isScheduledThisWeek),
+  Array.filter(Appointment.hasMinimumDuration(Duration.hours(2)))
+)
+
+// Sort by multiple criteria
+const sorted = pipe(
+  appointments,
+  Array.sort(
+    Order.combine(
+      Appointment.OrderByStatusPriority,
+      Appointment.OrderByScheduledTime
+    )
+  )
+)
+
+// Deduplicate and sort
+const uniqueSorted = pipe(
+  appointments,
+  Array.dedupeWith(Appointment.EquivalenceById),
+  Array.sort(Appointment.OrderByPriorityThenDate)
+)
+```
+
+## Checklist for Complete Coverage
+
+### Equality
+
+- [ ] Use `Schema.Data` for automatic `Equal.equals()`
+- [ ] Export `Schema.equivalence()` when needed for combinators
+- [ ] Export field-based equivalences using `Equivalence.mapInput`
+- [ ] Export combined equivalences using `Equivalence.combine`
+
+### Orders
+
+- [ ] Export orders for all sortable fields using `Order.mapInput`
+- [ ] Export combined orders using `Order.combine`
+- [ ] Document which field takes precedence in combined orders
+
+### Schedulable types
+
+- [ ] isScheduledBefore
+- [ ] isScheduledAfter
+- [ ] isScheduledBetween
+- [ ] isScheduledOn
+- [ ] isScheduledToday
+- [ ] isScheduledThisWeek
+- [ ] isScheduledThisMonth
+- [ ] All Order instances
+
+### Durable types
+
+- [ ] hasMinimumDuration (isMoreThan)
+- [ ] hasMaximumDuration (isLessThan)
+- [ ] hasDurationBetween (isBetween)
+- [ ] hasExactDuration
+- [ ] All Order instances
+
+### Domain-specific fields
+
+- [ ] Predicate for each variant (isPending, isActive, etc.)
+- [ ] Order by field value using `Order.mapInput`
+- [ ] Order by priority/importance if applicable
+- [ ] Combined orders for common sorting patterns
+
+## Key Patterns Summary
+
+**1. Schema.Data for Equality**
+
+```typescript
+Schema.TaggedStruct("task", { ... }).pipe(Schema.Data)
+// Usage: Equal.equals(t1, t2)
+```
+
+**2. Schema.equivalence() for Combinators**
+
+```typescript
+export const Equivalence = Schema.equivalence(Task)
+// Usage: Array.dedupeWith(tasks, Equivalence)
+```
+
+**3. Equivalence.mapInput for Field-Based**
+
+```typescript
+Equivalence.mapInput(Equivalence.string, (t: Task) => t.id)
+```
+
+**4. Equivalence.combine for Multi-Field**
+
+```typescript
+Equivalence.combine(EquivalenceByTag, EquivalenceById)
+```
+
+**5. Order.mapInput for Field-Based Sorting**
+
+```typescript
+Order.mapInput(Order.string, (t: Task) => t.id)
+```
+
+**6. Order.combine for Multi-Criteria Sorting**
+
+```typescript
+Order.combine(OrderByPriority, OrderByDate)
+```

--- a/effect-best-practices/references/effect-atom-patterns.md
+++ b/effect-best-practices/references/effect-atom-patterns.md
@@ -351,7 +351,7 @@ function Counter() {
     return <div>{count}</div>
 }
 
-// CORRECT - define atoms outside components
+// ✅ CORRECT - define atoms outside components
 const countAtom = Atom.make(0)
 
 function Counter() {
@@ -374,7 +374,7 @@ function Component() {
     return <button onClick={() => openModal("settings")}>Open</button>
 }
 
-// CORRECT - use hooks for React integration
+// ✅ CORRECT - use hooks for React integration
 export const useModal = (type: string) => {
     const state = useAtomValue(modalAtomFamily(type))
     const setState = useAtomSet(modalAtomFamily(type))
@@ -406,7 +406,7 @@ const scrollAtom = Atom.make((get) => {
     return window.scrollY
 })
 
-// CORRECT - cleanup registered
+// ✅ CORRECT - cleanup registered
 const scrollAtom = Atom.make((get) => {
     const onScroll = () => get.setSelf(window.scrollY)
     window.addEventListener("scroll", onScroll)
@@ -421,7 +421,7 @@ const scrollAtom = Atom.make((get) => {
 // WRONG - state resets when component unmounts
 export const modalStateAtom = Atom.make({ isOpen: false })
 
-// CORRECT - state persists
+// ✅ CORRECT - state persists
 export const modalStateAtom = Atom.make({ isOpen: false }).pipe(Atom.keepAlive)
 ```
 
@@ -432,7 +432,7 @@ export const modalStateAtom = Atom.make({ isOpen: false }).pipe(Atom.keepAlive)
 const userResult = useAtomValue(userAtom)
 return <div>Hello, {userResult.name}</div> // Type error!
 
-// CORRECT - use Result.builder to handle all states
+// ✅ CORRECT - use Result.builder to handle all states
 const userResult = useAtomValue(userAtom)
 return Result.builder(userResult)
     .onInitial(() => <div>Loading...</div>)
@@ -451,7 +451,7 @@ function Component() {
     return <div>{count}</div>
 }
 
-// CORRECT - use effects or event handlers
+// ✅ CORRECT - use effects or event handlers
 function Component() {
     const count = useAtomValue(countAtom)
     const setCount = useAtomSet(countAtom)
@@ -473,7 +473,7 @@ function Component() {
 const state = useAtomValue(appStateAtom)
 const userName = state.user.name
 
-// CORRECT - derive focused atom
+// ✅ CORRECT - derive focused atom
 const userNameAtom = Atom.map(appStateAtom, (state) => state.user.name)
 const userName = useAtomValue(userNameAtom)
 ```

--- a/effect-best-practices/references/effect-atom-patterns.md
+++ b/effect-best-practices/references/effect-atom-patterns.md
@@ -1,5 +1,17 @@
 # Effect Atom Patterns
 
+## Table of Contents
+
+- [Core Concepts](#core-concepts)
+- [Creating Atoms](#creating-atoms)
+- [Atom Families](#atom-families)
+- [React Integration](#react-integration)
+- [Working with Effects and Results](#working-with-effects-and-results)
+- [Batching Updates](#batching-updates)
+- [localStorage Persistence](#localstorage-persistence)
+- [Anti-Patterns](#anti-patterns)
+- [Performance Tips](#performance-tips)
+
 Effect Atom is a reactive state management library that integrates with Effect-TS. It provides atoms (reactive containers), automatic dependency tracking, and seamless React integration.
 
 ## Core Concepts

--- a/effect-best-practices/references/effect-atom-patterns.md
+++ b/effect-best-practices/references/effect-atom-patterns.md
@@ -5,8 +5,14 @@
 - [Core Concepts](#core-concepts)
 - [Creating Atoms](#creating-atoms)
 - [Atom Families](#atom-families)
+- [Function Atoms (Side Effects)](#function-atoms-side-effects)
+- [Runtime with Services](#runtime-with-services)
 - [React Integration](#react-integration)
 - [Working with Effects and Results](#working-with-effects-and-results)
+- [Stream Integration](#stream-integration)
+- [Pull Atoms (Pagination)](#pull-atoms-pagination)
+- [Scoped Resources & Finalizers](#scoped-resources--finalizers)
+- [Common Patterns](#common-patterns)
 - [Batching Updates](#batching-updates)
 - [localStorage Persistence](#localstorage-persistence)
 - [Anti-Patterns](#anti-patterns)
@@ -122,6 +128,80 @@ const modalAtomFamily = Atom.family((type: ModalType) =>
 - Form state per entity
 - Any parameterized state
 
+## Function Atoms (Side Effects)
+
+Use `Atom.fn` for operations with side effects:
+
+```typescript
+import { Atom } from "@effect-atom/atom-react"
+import { Effect } from "effect"
+
+interface CartState {
+    readonly items: ReadonlyArray<Item>
+    readonly total: number
+}
+
+const cart = Atom.make<CartState>({ items: [], total: 0 })
+
+const addItem = Atom.fn(
+    Effect.fnUntraced(function* (item: Item) {
+        const current = yield* Atom.get(cart)
+
+        yield* Atom.set(cart, {
+            items: [...current.items, item],
+            total: current.total + item.price,
+        })
+    })
+)
+
+const clearCart = Atom.fn(
+    Effect.fnUntraced(function* () {
+        yield* Atom.set(cart, { items: [], total: 0 })
+    })
+)
+```
+
+## Runtime with Services
+
+Wrap Effect layers/services for use in atoms:
+
+```typescript
+import { Atom } from "@effect-atom/atom-react"
+import { Effect, Layer } from "effect"
+
+const runtime = Atom.runtime(
+    Layer.mergeAll(
+        DatabaseService.Live,
+        LoggerService.Live,
+        ApiClient.Live
+    )
+)
+
+const fetchUserData = runtime.fn(
+    Effect.fnUntraced(function* (userId: string) {
+        const db = yield* DatabaseService
+        const user = yield* db.getUser(userId)
+
+        yield* Atom.set(userAtoms(userId), user)
+        return user
+    })
+)
+```
+
+### Global Layers
+
+Configure global layers once at app initialization:
+
+```typescript
+Atom.runtime.addGlobalLayer(
+    Layer.mergeAll(
+        Logger.Live,
+        Tracer.Live,
+        Config.Live
+    )
+)
+```
+
 ## React Integration
 
 ### Reading Atom Values
@@ -180,6 +260,31 @@ function App() {
     useAtomMount(themeApplierAtom)
 
     return <>{children}</>
+}
+```
+
+### Using Function Atoms with useAtomSetPromise
+
+For async function atoms, use `useAtomSetPromise`:
+
+```typescript
+import { useAtomValue, useAtomSet, useAtomSetPromise } from "@effect-atom/atom-react"
+
+function CartView() {
+    const cartData = useAtomValue(cart)
+    const addItem = useAtomSet(addItem)
+    const clearCart = useAtomSet(clearCart)
+
+    // For async function atoms that return promises
+    const fetchData = useAtomSetPromise(fetchUserData)
+
+    return (
+        <div>
+            <div>Items: {cartData.items.length}</div>
+            <button onClick={() => addItem(newItem)}>Add</button>
+            <button onClick={() => clearCart()}>Clear</button>
+        </div>
+    )
 }
 ```
 
@@ -314,6 +419,134 @@ const userProfileAtom = Atom.make(
         return { user, posts }
     })
 )
+```
+
+## Stream Integration
+
+Convert streams into atoms that capture the latest value:
+
+```typescript
+import { Atom } from "@effect-atom/atom-react"
+import { Stream } from "effect"
+
+const notifications = Atom.make(
+    Stream.fromEventListener(window, "notification").pipe(
+        Stream.map(parseNotification),
+        Stream.filter(isValid),
+        Stream.scan([], (acc, n) => [...acc, n].slice(-10))
+    )
+)
+```
+
+## Pull Atoms (Pagination)
+
+Use `Atom.pull` for stream-based pagination:
+
+```typescript
+import { Atom } from "@effect-atom/atom-react"
+import { Stream } from "effect"
+
+const pagedItems = Atom.pull(
+    Stream.fromIterable(itemsSource).pipe(
+        Stream.grouped(10) // Pages of 10 items
+    )
+)
+
+// In component - automatically fetches next page when called
+function ItemList() {
+    const loadMore = useAtomSet(pagedItems)
+    return <button onClick={() => loadMore()}>Load More</button>
+}
+```
+
+## Scoped Resources & Finalizers
+
+Atoms support scoped effects with automatic cleanup using `Effect.acquireRelease`:
+
+```typescript
+import { Atom } from "@effect-atom/atom-react"
+import { Effect } from "effect"
+
+const wsConnection = Atom.make(
+    Effect.gen(function* () {
+        const ws = yield* Effect.acquireRelease(
+            connectWebSocket(),
+            (ws) => Effect.sync(() => ws.close())
+        )
+
+        return ws
+    })
+)
+
+// Finalizer runs when atom rebuilds or becomes unused
+```
+
+## Common Patterns
+
+### Loading States
+
+```typescript
+import { Atom, Result } from "@effect-atom/atom-react"
+import { Effect } from "effect"
+
+const userDataAtom = Atom.make<Result<User, Error>>(Result.initial)
+
+const loadUser = runtime.fn(
+    Effect.fnUntraced(function* (id: string) {
+        yield* Atom.set(userDataAtom, Result.initial)
+
+        const result = yield* Effect.either(userService.fetchUser(id))
+
+        yield* Atom.set(
+            userDataAtom,
+            result._tag === "Right"
+                ? Result.success(result.right)
+                : Result.failure(result.left)
+        )
+    })
+)
+```
+
+### Optimistic Updates
+
+```typescript
+const updateItem = runtime.fn(
+    Effect.fnUntraced(function* (id: string, updates: Partial<Item>) {
+        const current = yield* Atom.get(itemsAtom)
+
+        // Optimistic update
+        yield* Atom.set(
+            itemsAtom,
+            current.map((item) =>
+                item.id === id ? { ...item, ...updates } : item
+            )
+        )
+
+        // Persist to server
+        const result = yield* Effect.either(api.updateItem(id, updates))
+
+        // Revert on failure
+        if (result._tag === "Left") {
+            yield* Atom.set(itemsAtom, current)
+        }
+    })
+)
+```
+
+### Computed Queries
+
+```typescript
+const filteredItems = Atom.make((get) => {
+    const items = get(itemsAtom)
+    const searchTerm = get(searchAtom)
+    const activeFilters = get(filtersAtom)
+
+    return items.filter(
+        (item) =>
+            item.name.includes(searchTerm) &&
+            activeFilters.every((f) => f.predicate(item))
+    )
+})
 ```
 
 ## Batching Updates

--- a/effect-best-practices/references/effect-test-patterns.md
+++ b/effect-best-practices/references/effect-test-patterns.md
@@ -28,6 +28,121 @@ it.effect("should fetch user", () =>
 )
 ```
 
+## Test Variants
+
+### it.effect - Default Test Environment
+
+Provides TestContext including TestClock, TestRandom, etc.
+
+```typescript
+import { it, expect } from "@effect/vitest"
+import { Effect } from "effect"
+
+declare const someEffect: Effect.Effect<number>
+declare const expected: number
+
+it.effect("test name", () =>
+  Effect.gen(function* () {
+    // Test implementation with TestContext available
+    const result = yield* someEffect
+    expect(result).toBe(expected)
+  })
+)
+```
+
+### it.live - Live Environment
+
+Uses real services (real clock, real random, etc.).
+
+```typescript
+import { it } from "@effect/vitest"
+import { Effect, Clock } from "effect"
+
+it.live("test with real time", () =>
+  Effect.gen(function* () {
+    const now = yield* Clock.currentTimeMillis
+    // Uses actual system time
+  })
+)
+```
+
+### it.scoped - Resource Management
+
+For tests requiring Scope to manage resource lifecycle.
+
+```typescript
+import { it } from "@effect/vitest"
+import { Effect } from "effect"
+
+declare const acquire: Effect.Effect<unknown>
+declare const release: Effect.Effect<void>
+
+it.scoped("test with resources", () =>
+  Effect.gen(function* () {
+    const resource = yield* Effect.acquireRelease(
+      acquire,
+      () => release
+    )
+    // Resource automatically cleaned up after test
+  })
+)
+```
+
+### it.scopedLive - Combined Scoped + Live
+
+Uses live environment with scope for resource management.
+
+```typescript
+import { it } from "@effect/vitest"
+import { Effect } from "effect"
+
+declare const acquireRealResource: Effect.Effect<unknown>
+declare const releaseRealResource: Effect.Effect<void>
+
+it.scopedLive("live test with resources", () =>
+  Effect.gen(function* () {
+    const resource = yield* Effect.acquireRelease(
+      acquireRealResource,
+      () => releaseRealResource
+    )
+  })
+)
+```
+
+## Effect-Specific Utilities
+
+`@effect/vitest` provides additional assertion utilities in `utils`:
+
+```typescript
+import { it } from "@effect/vitest"
+import {
+  assertEquals,       // Uses Effect's Equal.equals
+  assertTrue,
+  assertFalse,
+  assertSome,        // For Option.Some
+  assertNone,        // For Option.None
+  assertRight,       // For Either.Right
+  assertLeft,        // For Either.Left
+  assertSuccess,     // For Exit.Success
+  assertFailure      // For Exit.Failure
+} from "@effect/vitest/utils"
+import { Effect, Option, Either } from "effect"
+
+declare const someOptionalEffect: Effect.Effect<Option.Option<number>>
+declare const someEitherEffect: Effect.Effect<Either.Either<number, Error>>
+declare const expectedValue: number
+
+it.effect("with effect assertions", () =>
+  Effect.gen(function* () {
+    const option = yield* someOptionalEffect
+    assertSome(option, expectedValue)
+
+    const either = yield* someEitherEffect
+    assertRight(either, expectedValue)
+  })
+)
+```
+
 ## Testing with Effect.gen
 
 ```typescript
@@ -167,7 +282,66 @@ describe("User Repository", () => {
 
 ## Testing Error Scenarios
 
-### Testing Expected Errors
+### Testing Error Types
+
+```typescript
+import { it, expect } from "@effect/vitest"
+import { Effect, Exit, Cause, Context, Data } from "effect"
+
+class NotFoundError extends Data.TaggedError("NotFoundError")<{
+  id: string
+}> {}
+
+class UserService extends Context.Tag("UserService")<UserService, {
+  getUser: (id: string) => Effect.Effect<unknown, NotFoundError>
+}>() {}
+
+declare const userService: {
+  getUser: (id: string) => Effect.Effect<unknown, NotFoundError>
+}
+
+it.effect("should fail with specific error", () =>
+  Effect.gen(function* () {
+    const exit = yield* Effect.exit(
+      userService.getUser("nonexistent")
+    )
+
+    if (Exit.isFailure(exit)) {
+      const cause = exit.cause
+      expect(Cause.isFailType(cause)).toBe(true)
+      const error = Cause.failureOrCause(cause)
+      expect(error).toBeInstanceOf(NotFoundError)
+    } else {
+      throw new Error("Expected failure")
+    }
+  })
+)
+```
+
+### Testing Expected Failures with Effect.flip
+
+Use `Effect.flip` to convert failures to successes for simpler assertions:
+
+```typescript
+import { it, expect } from "@effect/vitest"
+import { Effect, Data } from "effect"
+
+class UserNotFoundError extends Data.TaggedError("UserNotFoundError")<{
+  userId: string
+}> {}
+
+declare const failingOperation: () => Effect.Effect<never, UserNotFoundError>
+
+it.effect("should fail with error", () =>
+  Effect.gen(function* () {
+    const error = yield* Effect.flip(failingOperation())
+    expect(error).toBeInstanceOf(UserNotFoundError)
+    expect(error.userId).toBe("123")
+  })
+)
+```
+
+### Testing Error Recovery
 
 ```typescript
 import { it, expect, describe } from "@effect/vitest"
@@ -184,16 +358,113 @@ describe("Error Handling", () => {
       expect(result.name).toBe("Guest")
     }).pipe(Effect.provide(TestLayer))
   )
-
-  it.effect("should propagate unhandled errors", () =>
-    Effect.gen(function* () {
-      const exit = yield* Effect.exit(
-        fetchUser("999").pipe(Effect.provide(TestLayer))
-      )
-      expect(Exit.isFailure(exit)).toBe(true)
-    })
-  )
 })
+```
+
+## Time-Dependent Testing with TestClock
+
+### Basic TestClock Usage
+
+TestClock allows controlling time without waiting:
+
+```typescript
+import { it, expect } from "@effect/vitest"
+import { Effect, TestClock, Fiber } from "effect"
+
+it.effect("should handle delays", () =>
+  Effect.gen(function* () {
+    const fiber = yield* Effect.fork(
+      Effect.sleep("5 seconds").pipe(Effect.as("done"))
+    )
+
+    // Advance time by 5 seconds instantly
+    yield* TestClock.adjust("5 seconds")
+
+    const result = yield* Fiber.join(fiber)
+    expect(result).toBe("done")
+  })
+)
+```
+
+### Testing Recurring Effects
+
+Test periodic operations efficiently:
+
+```typescript
+import { it, expect } from "@effect/vitest"
+import { Effect, Queue, TestClock, Option } from "effect"
+
+it.effect("should execute every minute", () =>
+  Effect.gen(function* () {
+    const queue = yield* Queue.unbounded<number>()
+
+    // Fork effect that repeats every minute
+    yield* Effect.fork(
+      Queue.offer(queue, 1).pipe(
+        Effect.delay("60 seconds"),
+        Effect.forever
+      )
+    )
+
+    // No effect before time passes
+    const empty = yield* Queue.poll(queue)
+    expect(Option.isNone(empty)).toBe(true)
+
+    // Advance time
+    yield* TestClock.adjust("60 seconds")
+
+    // Effect executed once
+    const value = yield* Queue.take(queue)
+    expect(value).toBe(1)
+
+    // Verify only one execution
+    const stillEmpty = yield* Queue.poll(queue)
+    expect(Option.isNone(stillEmpty)).toBe(true)
+  })
+)
+```
+
+### Testing Clock Methods
+
+```typescript
+import { it, expect } from "@effect/vitest"
+import { Effect, Clock, TestClock } from "effect"
+
+it.effect("should track time correctly", () =>
+  Effect.gen(function* () {
+    const start = yield* Clock.currentTimeMillis
+
+    yield* TestClock.adjust("1 minute")
+
+    const end = yield* Clock.currentTimeMillis
+
+    expect(end - start).toBeGreaterThanOrEqual(60_000)
+  })
+)
+```
+
+### TestClock with Deferred
+
+```typescript
+import { it, expect } from "@effect/vitest"
+import { Effect, Deferred, TestClock } from "effect"
+
+it.effect("should handle deferred with delays", () =>
+  Effect.gen(function* () {
+    const deferred = yield* Deferred.make<number, void>()
+
+    yield* Effect.fork(
+      Effect.sleep("10 seconds").pipe(
+        Effect.zipRight(Deferred.succeed(deferred, 42))
+      )
+    )
+
+    yield* TestClock.adjust("10 seconds")
+
+    const result = yield* Deferred.await(deferred)
+    expect(result).toBe(42)
+  })
+)
 ```
 
 ## Testing Resource Management

--- a/effect-best-practices/references/effect-test-patterns.md
+++ b/effect-best-practices/references/effect-test-patterns.md
@@ -1,5 +1,20 @@
 # Effect Testing Patterns
 
+## Table of Contents
+
+- [Framework Selection](#framework-selection)
+- [Test Variants](#test-variants)
+- [Effect-Specific Utilities](#effect-specific-utilities)
+- [Testing with Effect.gen](#testing-with-effectgen)
+- [Testing Success and Failure](#testing-success-and-failure)
+- [Mock Layers for Testing](#mock-layers-for-testing)
+- [Testing Error Scenarios](#testing-error-scenarios)
+- [Time-Dependent Testing with TestClock](#time-dependent-testing-with-testclock)
+- [Testing Resource Management](#testing-resource-management)
+- [Property-Based Testing](#property-based-testing)
+- [Testing Best Practices](#testing-best-practices)
+- [Common Pitfalls](#common-pitfalls)
+
 ## Framework Selection
 
 **CRITICAL**: Choose the correct testing framework based on the code being tested.

--- a/effect-best-practices/references/effect-test-patterns.md
+++ b/effect-best-practices/references/effect-test-patterns.md
@@ -1,0 +1,421 @@
+# Effect Testing Patterns
+
+## Framework Selection
+
+**CRITICAL**: Choose the correct testing framework based on the code being tested.
+
+### Use @effect/vitest for Effect Code
+
+Use `@effect/vitest` when testing:
+
+- Functions that return `Effect<A, E, R>`
+- Code that uses services and layers
+- Time-dependent operations with TestClock
+- Asynchronous operations coordinated with Effect
+- STM (Software Transactional Memory) operations
+
+```typescript
+import { it, expect } from "@effect/vitest"
+import { Effect } from "effect"
+
+declare const fetchUser: (id: string) => Effect.Effect<{ id: string }, Error>
+
+it.effect("should fetch user", () =>
+  Effect.gen(function* () {
+    const user = yield* fetchUser("123")
+    expect(user.id).toBe("123")
+  })
+)
+```
+
+## Testing with Effect.gen
+
+```typescript
+import { it, expect, describe } from "@effect/vitest"
+import { Effect } from "effect"
+
+describe("User Service", () => {
+  it.effect("should fetch user by ID", () =>
+    Effect.gen(function* () {
+      const user = yield* fetchUser("123").pipe(Effect.provide(TestLayer))
+      expect(user.id).toBe("123")
+      expect(user.name).toBe("Alice")
+    })
+  )
+})
+```
+
+## Testing Success and Failure
+
+```typescript
+import { it, expect, describe } from "@effect/vitest"
+import { Effect, Exit, Cause } from "effect"
+
+describe("Validation", () => {
+  it.effect("should succeed with valid email", () =>
+    Effect.gen(function* () {
+      const result = yield* validateEmail("alice@example.com")
+      expect(result).toBe("alice@example.com")
+    })
+  )
+
+  it.effect("should fail with invalid email", () =>
+    Effect.gen(function* () {
+      const exit = yield* Effect.exit(validateEmail("invalid"))
+      expect(Exit.isFailure(exit)).toBe(true)
+      if (Exit.isFailure(exit)) {
+        const error = Cause.failureOption(exit.cause)
+        expect(error._tag).toBe("ValidationError")
+      }
+    })
+  )
+})
+```
+
+## Mock Layers for Testing
+
+### Creating Test Layers
+
+```typescript
+import { Context, Effect, Layer } from "effect"
+
+interface UserRepository {
+  findById: (id: string) => Effect.Effect<Option<User>, DbError, never>
+  save: (user: User) => Effect.Effect<User, DbError, never>
+}
+
+const UserRepository = Context.GenericTag<UserRepository>("UserRepository")
+
+// In-memory test implementation
+const UserRepositoryTest = Layer.succeed(
+  UserRepository,
+  {
+    findById: (id: string) =>
+      Effect.succeed(
+        id === "1"
+          ? Option.some({ id: "1", name: "Alice", email: "alice@example.com" })
+          : Option.none()
+      ),
+
+    save: (user: User) =>
+      Effect.succeed(user)
+  }
+)
+
+// Use in tests
+const testProgram = Effect.gen(function* () {
+  const repo = yield* UserRepository
+  const user = yield* repo.findById("1")
+  return user
+}).pipe(
+  Effect.provide(UserRepositoryTest)
+)
+```
+
+### Stateful Mock Layers
+
+```typescript
+import { Context, Effect, Layer, Ref } from "effect"
+
+// Mock with state
+const UserRepositoryStateful = Layer.effect(
+  UserRepository,
+  Effect.gen(function* () {
+    const storage = yield* Ref.make<Map<string, User>>(new Map([
+      ["1", { id: "1", name: "Alice", email: "alice@example.com" }]
+    ]))
+
+    return {
+      findById: (id: string) =>
+        storage.get.pipe(
+          Effect.map((map) => {
+            const user = map.get(id)
+            return user ? Option.some(user) : Option.none()
+          })
+        ),
+
+      save: (user: User) =>
+        storage.update((map) => map.set(user.id, user)).pipe(
+          Effect.map(() => user)
+        )
+    }
+  })
+)
+
+// Test with state
+import { it, expect, describe } from "@effect/vitest"
+import { Option } from "effect"
+
+describe("User Repository", () => {
+  it.effect("should save and retrieve user", () =>
+    Effect.gen(function* () {
+      const repo = yield* UserRepository
+
+      const newUser = { id: "2", name: "Bob", email: "bob@example.com" }
+      yield* repo.save(newUser)
+
+      const result = yield* repo.findById("2")
+
+      expect(Option.isSome(result)).toBe(true)
+      if (Option.isSome(result)) {
+        expect(result.value.name).toBe("Bob")
+      }
+    }).pipe(Effect.provide(UserRepositoryStateful))
+  )
+})
+```
+
+## Testing Error Scenarios
+
+### Testing Expected Errors
+
+```typescript
+import { it, expect, describe } from "@effect/vitest"
+import { Effect } from "effect"
+
+describe("Error Handling", () => {
+  it.effect("should handle NotFoundError", () =>
+    Effect.gen(function* () {
+      const result = yield* fetchUser("999").pipe(
+        Effect.catchTag("NotFoundError", () =>
+          Effect.succeed({ id: "default", name: "Guest" })
+        )
+      )
+      expect(result.name).toBe("Guest")
+    }).pipe(Effect.provide(TestLayer))
+  )
+
+  it.effect("should propagate unhandled errors", () =>
+    Effect.gen(function* () {
+      const exit = yield* Effect.exit(
+        fetchUser("999").pipe(Effect.provide(TestLayer))
+      )
+      expect(Exit.isFailure(exit)).toBe(true)
+    })
+  )
+})
+```
+
+## Testing Resource Management
+
+### Testing Cleanup
+
+```typescript
+import { it, expect, describe } from "@effect/vitest"
+import { Effect, Ref } from "effect"
+
+describe("Resource Management", () => {
+  it.effect("should clean up resources on success", () =>
+    Effect.gen(function* () {
+      const cleaned = yield* Ref.make(false)
+
+      yield* Effect.scoped(
+        Effect.gen(function* () {
+          yield* Effect.addFinalizer(() => Ref.set(cleaned, true))
+          yield* Effect.succeed("done")
+        })
+      )
+
+      const result = yield* Ref.get(cleaned)
+      expect(result).toBe(true)
+    })
+  )
+
+  it.effect("should clean up resources on failure", () =>
+    Effect.gen(function* () {
+      const cleaned = yield* Ref.make(false)
+
+      const result = yield* Effect.scoped(
+        Effect.gen(function* () {
+          yield* Effect.addFinalizer(() => Ref.set(cleaned, true))
+          yield* Effect.fail({ _tag: "TestError" as const })
+        })
+      ).pipe(Effect.catchAll(() => Effect.succeed("handled")))
+
+      const wasCleanedUp = yield* Ref.get(cleaned)
+      expect(result).toBe("handled")
+      expect(wasCleanedUp).toBe(true)
+    })
+  )
+})
+```
+
+## Property-Based Testing
+
+### Using it.prop for Pure Properties
+
+```typescript
+import { FastCheck } from "effect"
+import { it } from "@effect/vitest"
+
+it.prop(
+  "addition is commutative",
+  [FastCheck.integer(), FastCheck.integer()],
+  ([a, b]) => a + b === b + a
+)
+
+// With object syntax
+it.prop(
+  "multiplication distributes",
+  { a: FastCheck.integer(), b: FastCheck.integer(), c: FastCheck.integer() },
+  ({ a, b, c }) => a * (b + c) === a * b + a * c
+)
+```
+
+### Using it.effect.prop for Effect Properties
+
+```typescript
+import { it } from "@effect/vitest"
+import { Effect, Context, FastCheck } from "effect"
+
+class Database extends Context.Tag("Database")<Database, {
+  set: (key: string, value: number) => Effect.Effect<void>
+  get: (key: string) => Effect.Effect<number>
+}>() {}
+
+it.effect.prop(
+  "database operations are idempotent",
+  [FastCheck.string(), FastCheck.integer()],
+  ([key, value]) =>
+    Effect.gen(function* () {
+      const db = yield* Database
+
+      yield* db.set(key, value)
+      const result1 = yield* db.get(key)
+
+      yield* db.set(key, value)
+      const result2 = yield* db.get(key)
+
+      return result1 === result2
+    })
+)
+```
+
+### With Schema Arbitraries
+
+```typescript
+import { it, expect } from "@effect/vitest"
+import { Effect, Schema } from "effect"
+
+const User = Schema.Struct({
+  id: Schema.String,
+  age: Schema.Number.pipe(Schema.between(0, 120))
+})
+
+it.effect.prop(
+  "user validation works",
+  { user: User },
+  ({ user }) =>
+    Effect.gen(function* () {
+      expect(user.age).toBeGreaterThanOrEqual(0)
+      expect(user.age).toBeLessThanOrEqual(120)
+      return true
+    })
+)
+```
+
+### Configuring FastCheck
+
+```typescript
+import { it } from "@effect/vitest"
+import { Effect, FastCheck } from "effect"
+
+it.effect.prop(
+  "property test",
+  [FastCheck.integer()],
+  ([n]) => Effect.succeed(n >= 0 || n < 0),
+  {
+    timeout: 10000,
+    fastCheck: {
+      numRuns: 1000,
+      seed: 42,
+      verbose: true
+    }
+  }
+)
+```
+
+## Testing Best Practices
+
+### Test Organization
+
+```typescript
+import { it, expect, describe } from "@effect/vitest"
+import { Effect, Layer, Exit } from "effect"
+
+describe("User Service", () => {
+  const TestLayer = Layer.merge(UserRepositoryTest, LoggerTest, ConfigTest)
+
+  describe("createUser", () => {
+    it.effect("should create user with valid data", () =>
+      Effect.gen(function* () {
+        const service = yield* UserService
+        const user = yield* service.createUser({
+          name: "Alice",
+          email: "alice@example.com"
+        })
+        expect(user.name).toBe("Alice")
+      }).pipe(Effect.provide(TestLayer))
+    )
+
+    it.effect("should fail with invalid email", () =>
+      Effect.gen(function* () {
+        const service = yield* UserService
+        const exit = yield* Effect.exit(
+          service.createUser({ name: "Bob", email: "invalid" })
+        )
+        expect(Exit.isFailure(exit)).toBe(true)
+      }).pipe(Effect.provide(TestLayer))
+    )
+  })
+})
+```
+
+## Best Practices
+
+1. **Use Test Layers**: Create dedicated test implementations for services.
+
+2. **Test Error Paths**: Test both success and failure scenarios.
+
+3. **Mock Dependencies, Not the System Under Test**: Only mock the services your code depends on, never the service you are testing. The service under test should use its real implementation.
+
+4. **Test Cleanup**: Ensure resources are cleaned up properly.
+
+5. **Use Property Tests**: Test invariants with property-based testing.
+
+6. **Isolate Tests**: Each test should be independent.
+
+7. **Test Interruption**: Verify correct behavior on interruption.
+
+8. **Use Spies**: Track calls to verify behavior.
+
+9. **Test Edge Cases**: Cover boundary conditions and error cases.
+
+## Common Pitfalls
+
+1. **Not Providing Layers**: Forgetting to provide required services.
+
+2. **Shared State**: Tests interfering with each other via shared state.
+
+3. **Not Testing Errors**: Only testing happy paths.
+
+4. **Missing Cleanup Tests**: Not verifying finalizers execute.
+
+5. **Ignoring Concurrency**: Not testing concurrent behavior.
+
+6. **Flaky Tests**: Race conditions in concurrent tests.
+
+7. **Over-Mocking**: Mocking too much, losing integration value.
+
+8. **Not Testing Interruption**: Missing interruption scenarios.
+
+9. **Hardcoded Timing**: Tests that depend on specific timing.
+
+10. **Missing Exit Checks**: Not verifying Exit values properly.
+
+## Resources
+
+### Testing Libraries
+
+- [Vitest](https://vitest.dev/)
+- [fast-check](https://github.com/dubzzz/fast-check)

--- a/effect-best-practices/references/error-patterns.md
+++ b/effect-best-practices/references/error-patterns.md
@@ -4,14 +4,15 @@
 
 Generic errors like `BadRequestError` or `NotFoundError` seem convenient but create problems:
 
-| Generic Error | Problems |
-|--------------|----------|
-| `NotFoundError` | Which resource? How should frontend recover? |
-| `BadRequestError` | What's invalid? Can user fix it? |
-| `UnauthorizedError` | Session expired? Wrong credentials? Missing permission? |
-| `InternalServerError` | Retryable? User action needed? |
+| Generic Error         | Problems                                                |
+| --------------------- | ------------------------------------------------------- |
+| `NotFoundError`       | Which resource? How should frontend recover?            |
+| `BadRequestError`     | What's invalid? Can user fix it?                        |
+| `UnauthorizedError`   | Session expired? Wrong credentials? Missing permission? |
+| `InternalServerError` | Retryable? User action needed?                          |
 
 **Explicit errors enable:**
+
 1. **Specific UI messages** - "Your session expired" vs generic "Unauthorized"
 2. **Targeted recovery** - Refresh token vs show login page
 3. **Better observability** - Group errors by specific type in dashboards
@@ -22,17 +23,20 @@ Generic errors like `BadRequestError` or `NotFoundError` seem convenient but cre
 ```typescript
 // ❌ WRONG - Collapsing to generic HTTP errors
 export class NotFoundError extends Schema.TaggedError<NotFoundError>()(
-    "NotFoundError",
-    { message: Schema.String },
-    HttpApiSchema.annotations({ status: 404 }),
+  "NotFoundError",
+  { message: Schema.String },
+  HttpApiSchema.annotations({ status: 404 }),
 ) {}
 
 // At API boundaries:
 Effect.catchTags({
-    UserNotFoundError: (err) => Effect.fail(new NotFoundError({ message: "Not found" })),
-    ChannelNotFoundError: (err) => Effect.fail(new NotFoundError({ message: "Not found" })),
-    MessageNotFoundError: (err) => Effect.fail(new NotFoundError({ message: "Not found" })),
-})
+  UserNotFoundError: (err) =>
+    Effect.fail(new NotFoundError({ message: "Not found" })),
+  ChannelNotFoundError: (err) =>
+    Effect.fail(new NotFoundError({ message: "Not found" })),
+  MessageNotFoundError: (err) =>
+    Effect.fail(new NotFoundError({ message: "Not found" })),
+});
 
 // Frontend receives: { _tag: "NotFoundError", message: "Not found" }
 // - Can't show specific message ("User doesn't exist" vs "Channel was deleted")
@@ -64,13 +68,13 @@ Result.builder(result)
 
 ## Error Naming Conventions
 
-| Pattern | Example | Use For |
-|---------|---------|---------|
-| `{Entity}NotFoundError` | `UserNotFoundError`, `ChannelNotFoundError` | Resource lookups |
-| `{Entity}{Action}Error` | `UserCreateError`, `MessageUpdateError` | Mutations that fail |
-| `{Feature}Error` | `SessionExpiredError`, `RateLimitExceededError` | Feature-specific failures |
-| `{Integration}Error` | `WorkOSUserFetchError`, `StripePaymentError` | External service errors |
-| `Invalid{Field}Error` | `InvalidEmailError`, `InvalidPasswordError` | Validation failures |
+| Pattern                 | Example                                         | Use For                   |
+| ----------------------- | ----------------------------------------------- | ------------------------- |
+| `{Entity}NotFoundError` | `UserNotFoundError`, `ChannelNotFoundError`     | Resource lookups          |
+| `{Entity}{Action}Error` | `UserCreateError`, `MessageUpdateError`         | Mutations that fail       |
+| `{Feature}Error`        | `SessionExpiredError`, `RateLimitExceededError` | Feature-specific failures |
+| `{Integration}Error`    | `WorkOSUserFetchError`, `StripePaymentError`    | External service errors   |
+| `Invalid{Field}Error`   | `InvalidEmailError`, `InvalidPasswordError`     | Validation failures       |
 
 ### Rich Error Context
 
@@ -79,45 +83,45 @@ Include context fields that help with debugging and UI handling:
 ```typescript
 // Entity errors → include entity ID
 export class UserNotFoundError extends Schema.TaggedError<UserNotFoundError>()(
-    "UserNotFoundError",
-    {
-        userId: UserId,         // Which user?
-        message: Schema.String,
-    },
-    HttpApiSchema.annotations({ status: 404 }),
+  "UserNotFoundError",
+  {
+    userId: UserId, // Which user?
+    message: Schema.String,
+  },
+  HttpApiSchema.annotations({ status: 404 }),
 ) {}
 
 // Action errors → include input that failed
 export class UserCreateError extends Schema.TaggedError<UserCreateError>()(
-    "UserCreateError",
-    {
-        email: Schema.String,   // What email failed?
-        reason: Schema.String,  // Why? "duplicate", "invalid domain"
-        message: Schema.String,
-    },
-    HttpApiSchema.annotations({ status: 400 }),
+  "UserCreateError",
+  {
+    email: Schema.String, // What email failed?
+    reason: Schema.String, // Why? "duplicate", "invalid domain"
+    message: Schema.String,
+  },
+  HttpApiSchema.annotations({ status: 400 }),
 ) {}
 
 // Integration errors → include service name and retryable flag
 export class StripePaymentError extends Schema.TaggedError<StripePaymentError>()(
-    "StripePaymentError",
-    {
-        stripeErrorCode: Schema.String,
-        retryable: Schema.Boolean,
-        message: Schema.String,
-    },
-    HttpApiSchema.annotations({ status: 402 }),
+  "StripePaymentError",
+  {
+    stripeErrorCode: Schema.String,
+    retryable: Schema.Boolean,
+    message: Schema.String,
+  },
+  HttpApiSchema.annotations({ status: 402 }),
 ) {}
 
 // Auth errors → include expiry info
 export class SessionExpiredError extends Schema.TaggedError<SessionExpiredError>()(
-    "SessionExpiredError",
-    {
-        sessionId: SessionId,
-        expiredAt: Schema.DateTimeUtc,
-        message: Schema.String,
-    },
-    HttpApiSchema.annotations({ status: 401 }),
+  "SessionExpiredError",
+  {
+    sessionId: SessionId,
+    expiredAt: Schema.DateTimeUtc,
+    message: Schema.String,
+  },
+  HttpApiSchema.annotations({ status: 401 }),
 ) {}
 ```
 
@@ -133,48 +137,49 @@ export class SessionExpiredError extends Schema.TaggedError<SessionExpiredError>
 ### Basic Error Definition
 
 ```typescript
-import { Schema } from "effect"
-import { HttpApiSchema } from "@effect/platform"
+import { Schema } from "effect";
+import { HttpApiSchema } from "@effect/platform";
 
 export class UserNotFoundError extends Schema.TaggedError<UserNotFoundError>()(
-    "UserNotFoundError",
-    {
-        userId: UserId,
-        message: Schema.String,
-    },
-    HttpApiSchema.annotations({ status: 404 }),
+  "UserNotFoundError",
+  {
+    userId: UserId,
+    message: Schema.String,
+  },
+  HttpApiSchema.annotations({ status: 404 }),
 ) {}
 
 export class UserCreateError extends Schema.TaggedError<UserCreateError>()(
-    "UserCreateError",
-    {
-        message: Schema.String,
-        cause: Schema.optional(Schema.String),
-    },
-    HttpApiSchema.annotations({ status: 400 }),
+  "UserCreateError",
+  {
+    message: Schema.String,
+    cause: Schema.optional(Schema.String),
+  },
+  HttpApiSchema.annotations({ status: 400 }),
 ) {}
 
 export class UnauthorizedError extends Schema.TaggedError<UnauthorizedError>()(
-    "UnauthorizedError",
-    {
-        message: Schema.String,
-    },
-    HttpApiSchema.annotations({ status: 401 }),
+  "UnauthorizedError",
+  {
+    message: Schema.String,
+  },
+  HttpApiSchema.annotations({ status: 401 }),
 ) {}
 
 export class ForbiddenError extends Schema.TaggedError<ForbiddenError>()(
-    "ForbiddenError",
-    {
-        message: Schema.String,
-        requiredPermission: Schema.optional(Schema.String),
-    },
-    HttpApiSchema.annotations({ status: 403 }),
+  "ForbiddenError",
+  {
+    message: Schema.String,
+    requiredPermission: Schema.optional(Schema.String),
+  },
+  HttpApiSchema.annotations({ status: 403 }),
 ) {}
 ```
 
 ### Required Fields
 
 Every error should have:
+
 - `message: Schema.String` - Human-readable description
 - Relevant context fields (IDs, etc.)
 - Optional `cause: Schema.optional(Schema.String)` for error chains
@@ -187,52 +192,63 @@ Every error should have:
 
 ```typescript
 const findUser = Effect.fn("UserService.findUser")(function* (id: UserId) {
-    return yield* repo.findById(id).pipe(
-        Effect.catchTag("DatabaseError", (err) =>
-            Effect.fail(new UserNotFoundError({
-                userId: id,
-                message: `Database lookup failed: ${err.message}`,
-            }))
-        ),
-    )
-})
+  return yield* repo.findById(id).pipe(
+    Effect.catchTag("DatabaseError", (err) =>
+      Effect.fail(
+        new UserNotFoundError({
+          userId: id,
+          message: `Database lookup failed: ${err.message}`,
+        }),
+      ),
+    ),
+  );
+});
 ```
 
 ### catchTags for Multiple Error Types
 
 ```typescript
-const processOrder = Effect.fn("OrderService.processOrder")(function* (input: OrderInput) {
-    return yield* validateAndProcess(input).pipe(
-        Effect.catchTags({
-            ValidationError: (err) =>
-                Effect.fail(new OrderValidationError({
-                    message: err.message,
-                    field: err.field,
-                })),
-            PaymentError: (err) =>
-                Effect.fail(new OrderPaymentError({
-                    message: `Payment failed: ${err.message}`,
-                    code: err.code,
-                })),
-            InventoryError: (err) =>
-                Effect.fail(new OrderInventoryError({
-                    productId: err.productId,
-                    message: "Insufficient inventory",
-                })),
-        }),
-    )
-})
+const processOrder = Effect.fn("OrderService.processOrder")(function* (
+  input: OrderInput,
+) {
+  return yield* validateAndProcess(input).pipe(
+    Effect.catchTags({
+      ValidationError: (err) =>
+        Effect.fail(
+          new OrderValidationError({
+            message: err.message,
+            field: err.field,
+          }),
+        ),
+      PaymentError: (err) =>
+        Effect.fail(
+          new OrderPaymentError({
+            message: `Payment failed: ${err.message}`,
+            code: err.code,
+          }),
+        ),
+      InventoryError: (err) =>
+        Effect.fail(
+          new OrderInventoryError({
+            productId: err.productId,
+            message: "Insufficient inventory",
+          }),
+        ),
+    }),
+  );
+});
 ```
 
 ### Why Not catchAll?
 
 ```typescript
 // WRONG - Loses type information
-yield* effect.pipe(
+yield *
+  effect.pipe(
     Effect.catchAll((err) =>
-        Effect.fail(new InternalServerError({ message: "Something failed" }))
-    )
-)
+      Effect.fail(new InternalServerError({ message: "Something failed" })),
+    ),
+  );
 
 // Problems:
 // 1. Can't distinguish error types downstream
@@ -246,34 +262,38 @@ yield* effect.pipe(
 Create reusable error remapping functions for common transformations:
 
 ```typescript
-import { Effect } from "effect"
+import { Effect } from "effect";
 
 export const withRemapDbErrors = <A, E, R>(
-    effect: Effect.Effect<A, E | DatabaseError | ConnectionError, R>,
-    context: { entityType: string; entityId: string }
+  effect: Effect.Effect<A, E | DatabaseError | ConnectionError, R>,
+  context: { entityType: string; entityId: string },
 ): Effect.Effect<A, E | EntityNotFoundError | ServiceUnavailableError, R> =>
-    effect.pipe(
-        Effect.catchTag("DatabaseError", (err) =>
-            Effect.fail(new EntityNotFoundError({
-                entityType: context.entityType,
-                entityId: context.entityId,
-                message: `${context.entityType} not found`,
-            }))
-        ),
-        Effect.catchTag("ConnectionError", (err) =>
-            Effect.fail(new ServiceUnavailableError({
-                message: "Database connection unavailable",
-                cause: err.message,
-            }))
-        ),
-    )
+  effect.pipe(
+    Effect.catchTag("DatabaseError", (err) =>
+      Effect.fail(
+        new EntityNotFoundError({
+          entityType: context.entityType,
+          entityId: context.entityId,
+          message: `${context.entityType} not found`,
+        }),
+      ),
+    ),
+    Effect.catchTag("ConnectionError", (err) =>
+      Effect.fail(
+        new ServiceUnavailableError({
+          message: "Database connection unavailable",
+          cause: err.message,
+        }),
+      ),
+    ),
+  );
 
 // Usage
 const findUser = Effect.fn("UserService.findUser")(function* (id: UserId) {
-    return yield* repo.findById(id).pipe(
-        withRemapDbErrors({ entityType: "User", entityId: id })
-    )
-})
+  return yield* repo
+    .findById(id)
+    .pipe(withRemapDbErrors({ entityType: "User", entityId: id }));
+});
 ```
 
 ## Retryable Errors Pattern
@@ -282,56 +302,56 @@ For errors that may be transient, add a `retryable` property:
 
 ```typescript
 export class ServiceUnavailableError extends Schema.TaggedError<ServiceUnavailableError>()(
-    "ServiceUnavailableError",
-    {
-        message: Schema.String,
-        cause: Schema.optional(Schema.String),
-        retryable: Schema.optionalWith(Schema.Boolean, { default: () => true }),
-    },
-    HttpApiSchema.annotations({ status: 503 }),
+  "ServiceUnavailableError",
+  {
+    message: Schema.String,
+    cause: Schema.optional(Schema.String),
+    retryable: Schema.optionalWith(Schema.Boolean, { default: () => true }),
+  },
+  HttpApiSchema.annotations({ status: 503 }),
 ) {}
 
 export class RateLimitError extends Schema.TaggedError<RateLimitError>()(
-    "RateLimitError",
-    {
-        message: Schema.String,
-        retryAfter: Schema.optional(Schema.Number),
-        retryable: Schema.optionalWith(Schema.Boolean, { default: () => true }),
-    },
-    HttpApiSchema.annotations({ status: 429 }),
+  "RateLimitError",
+  {
+    message: Schema.String,
+    retryAfter: Schema.optional(Schema.Number),
+    retryable: Schema.optionalWith(Schema.Boolean, { default: () => true }),
+  },
+  HttpApiSchema.annotations({ status: 429 }),
 ) {}
 
 // Non-retryable error
 export class ValidationError extends Schema.TaggedError<ValidationError>()(
-    "ValidationError",
-    {
-        message: Schema.String,
-        field: Schema.String,
-        retryable: Schema.optionalWith(Schema.Boolean, { default: () => false }),
-    },
-    HttpApiSchema.annotations({ status: 400 }),
+  "ValidationError",
+  {
+    message: Schema.String,
+    field: Schema.String,
+    retryable: Schema.optionalWith(Schema.Boolean, { default: () => false }),
+  },
+  HttpApiSchema.annotations({ status: 400 }),
 ) {}
 ```
 
 ### Retry Based on Error Property
 
 ```typescript
-import { Effect, Schedule } from "effect"
+import { Effect, Schedule } from "effect";
 
 const withRetry = <A, E extends { retryable?: boolean }, R>(
-    effect: Effect.Effect<A, E, R>
+  effect: Effect.Effect<A, E, R>,
 ): Effect.Effect<A, E, R> =>
-    effect.pipe(
-        Effect.retry(
-            Schedule.exponential("100 millis").pipe(
-                Schedule.intersect(Schedule.recurs(3)),
-                Schedule.whileInput((err: E) => err.retryable === true),
-            )
-        ),
-    )
+  effect.pipe(
+    Effect.retry(
+      Schedule.exponential("100 millis").pipe(
+        Schedule.intersect(Schedule.recurs(3)),
+        Schedule.whileInput((err: E) => err.retryable === true),
+      ),
+    ),
+  );
 
 // Usage
-yield* callExternalApi(request).pipe(withRetry)
+yield * callExternalApi(request).pipe(withRetry);
 ```
 
 ## Error Unions for Activities
@@ -340,37 +360,36 @@ When defining workflow activities, use explicit error unions:
 
 ```typescript
 // Activity error type - union of possible errors
-export type GetChannelMembersError =
-    | DatabaseError
-    | ChannelNotFoundError
+export type GetChannelMembersError = DatabaseError | ChannelNotFoundError;
 
 export class DatabaseError extends Schema.TaggedError<DatabaseError>()(
-    "DatabaseError",
-    {
-        message: Schema.String,
-        cause: Schema.optional(Schema.String),
-        retryable: Schema.optionalWith(Schema.Boolean, { default: () => true }),
-    },
+  "DatabaseError",
+  {
+    message: Schema.String,
+    cause: Schema.optional(Schema.String),
+    retryable: Schema.optionalWith(Schema.Boolean, { default: () => true }),
+  },
 ) {}
 
 export class ChannelNotFoundError extends Schema.TaggedError<ChannelNotFoundError>()(
-    "ChannelNotFoundError",
-    {
-        channelId: ChannelId,
-        message: Schema.String,
-        retryable: Schema.optionalWith(Schema.Boolean, { default: () => false }),
-    },
+  "ChannelNotFoundError",
+  {
+    channelId: ChannelId,
+    message: Schema.String,
+    retryable: Schema.optionalWith(Schema.Boolean, { default: () => false }),
+  },
 ) {}
 
 // In activity definition
-yield* Activity.make({
+yield *
+  Activity.make({
     name: "GetChannelMembers",
     success: ChannelMembersResult,
     error: Schema.Union(DatabaseError, ChannelNotFoundError),
     execute: Effect.gen(function* () {
-        // ...
+      // ...
     }),
-})
+  });
 ```
 
 ## HTTP Status Codes (Without Generic Errors)
@@ -380,50 +399,58 @@ yield* Activity.make({
 ```typescript
 // ✅ CORRECT - Domain errors with HTTP status annotations
 export class UserNotFoundError extends Schema.TaggedError<UserNotFoundError>()(
-    "UserNotFoundError",
-    { userId: UserId, message: Schema.String },
-    HttpApiSchema.annotations({ status: 404 }),  // Status on specific error
+  "UserNotFoundError",
+  { userId: UserId, message: Schema.String },
+  HttpApiSchema.annotations({ status: 404 }), // Status on specific error
 ) {}
 
 export class ChannelNotFoundError extends Schema.TaggedError<ChannelNotFoundError>()(
-    "ChannelNotFoundError",
-    { channelId: ChannelId, message: Schema.String },
-    HttpApiSchema.annotations({ status: 404 }),  // Same status, different error
+  "ChannelNotFoundError",
+  { channelId: ChannelId, message: Schema.String },
+  HttpApiSchema.annotations({ status: 404 }), // Same status, different error
 ) {}
 
 export class SessionExpiredError extends Schema.TaggedError<SessionExpiredError>()(
-    "SessionExpiredError",
-    { sessionId: SessionId, expiredAt: Schema.DateTimeUtc, message: Schema.String },
-    HttpApiSchema.annotations({ status: 401 }),
+  "SessionExpiredError",
+  {
+    sessionId: SessionId,
+    expiredAt: Schema.DateTimeUtc,
+    message: Schema.String,
+  },
+  HttpApiSchema.annotations({ status: 401 }),
 ) {}
 
 export class InvalidCredentialsError extends Schema.TaggedError<InvalidCredentialsError>()(
-    "InvalidCredentialsError",
-    { message: Schema.String },
-    HttpApiSchema.annotations({ status: 401 }),  // Same status, different meaning
+  "InvalidCredentialsError",
+  { message: Schema.String },
+  HttpApiSchema.annotations({ status: 401 }), // Same status, different meaning
 ) {}
 ```
 
 ```typescript
 // ❌ WRONG - Generic HTTP error classes
 export class UnauthorizedError extends Schema.TaggedError<UnauthorizedError>()(
-    "UnauthorizedError",
-    { message: Schema.String },
-    HttpApiSchema.annotations({ status: 401 }),
+  "UnauthorizedError",
+  { message: Schema.String },
+  HttpApiSchema.annotations({ status: 401 }),
 ) {}
 
 // Then mapping everything to it - loses critical information!
 Effect.catchTags({
-    SessionExpiredError: (err) => Effect.fail(new UnauthorizedError({ message: "Unauthorized" })),
-    InvalidCredentialsError: (err) => Effect.fail(new UnauthorizedError({ message: "Unauthorized" })),
-    MissingTokenError: (err) => Effect.fail(new UnauthorizedError({ message: "Unauthorized" })),
-})
+  SessionExpiredError: (err) =>
+    Effect.fail(new UnauthorizedError({ message: "Unauthorized" })),
+  InvalidCredentialsError: (err) =>
+    Effect.fail(new UnauthorizedError({ message: "Unauthorized" })),
+  MissingTokenError: (err) =>
+    Effect.fail(new UnauthorizedError({ message: "Unauthorized" })),
+});
 // Frontend can't distinguish: expired session vs wrong password vs missing token
 ```
 
 ### When Generic Errors Are Acceptable
 
 Generic errors are only acceptable for **truly unrecoverable internal errors** where:
+
 - The frontend can only show "Something went wrong"
 - No user action can fix it
 - You're hiding internal details for security
@@ -431,18 +458,20 @@ Generic errors are only acceptable for **truly unrecoverable internal errors** w
 ```typescript
 // Acceptable for unrecoverable errors
 export class InternalServerError extends Schema.TaggedError<InternalServerError>()(
-    "InternalServerError",
-    { message: Schema.String, requestId: Schema.optional(Schema.String) },
-    HttpApiSchema.annotations({ status: 500 }),
+  "InternalServerError",
+  { message: Schema.String, requestId: Schema.optional(Schema.String) },
+  HttpApiSchema.annotations({ status: 500 }),
 ) {}
 
 // Use sparingly - only for truly unexpected errors
 Effect.catchAll((unexpectedError) =>
-    Effect.fail(new InternalServerError({
-        message: "An unexpected error occurred",
-        requestId: context.requestId,
-    }))
-)
+  Effect.fail(
+    new InternalServerError({
+      message: "An unexpected error occurred",
+      requestId: context.requestId,
+    }),
+  ),
+);
 ```
 
 ## Error Logging
@@ -450,15 +479,17 @@ Effect.catchAll((unexpectedError) =>
 Log errors with structured context:
 
 ```typescript
-const processWithLogging = Effect.fn("OrderService.process")(function* (orderId: OrderId) {
-    return yield* processOrder(orderId).pipe(
-        Effect.tapError((err) =>
-            Effect.log("Order processing failed", {
-                orderId,
-                errorTag: err._tag,
-                errorMessage: err.message,
-            })
-        ),
-    )
-})
+const processWithLogging = Effect.fn("OrderService.process")(function* (
+  orderId: OrderId,
+) {
+  return yield* processOrder(orderId).pipe(
+    Effect.tapError((err) =>
+      Effect.log("Order processing failed", {
+        orderId,
+        errorTag: err._tag,
+        errorMessage: err.message,
+      }),
+    ),
+  );
+});
 ```

--- a/effect-best-practices/references/error-patterns.md
+++ b/effect-best-practices/references/error-patterns.md
@@ -1,5 +1,17 @@
 # Error Patterns
 
+## Table of Contents
+
+- [Why Explicit Error Types?](#why-explicit-error-types)
+- [Error Naming Conventions](#error-naming-conventions)
+- [Schema.TaggedError for All Errors](#schemataggederror-for-all-errors)
+- [Error Handling with catchTag/catchTags](#error-handling-with-catchtagcatchtags)
+- [Error Remapping Pattern](#error-remapping-pattern)
+- [Retryable Errors Pattern](#retryable-errors-pattern)
+- [Error Unions for Activities](#error-unions-for-activities)
+- [HTTP Status Codes (Without Generic Errors)](#http-status-codes-without-generic-errors)
+- [Error Logging](#error-logging)
+
 ## Why Explicit Error Types?
 
 Generic errors like `BadRequestError` or `NotFoundError` seem convenient but create problems:

--- a/effect-best-practices/references/error-patterns.md
+++ b/effect-best-practices/references/error-patterns.md
@@ -40,15 +40,13 @@ export class NotFoundError extends Schema.TaggedError<NotFoundError>()(
   HttpApiSchema.annotations({ status: 404 }),
 ) {}
 
-// At API boundaries:
-Effect.catchTags({
-  UserNotFoundError: (err) =>
-    Effect.fail(new NotFoundError({ message: "Not found" })),
-  ChannelNotFoundError: (err) =>
-    Effect.fail(new NotFoundError({ message: "Not found" })),
-  MessageNotFoundError: (err) =>
-    Effect.fail(new NotFoundError({ message: "Not found" })),
-});
+// At API boundaries - collapsing to generic error AND using catchTags with duplicate handlers:
+Effect.catchTag(
+  "UserNotFoundError",
+  "ChannelNotFoundError",
+  "MessageNotFoundError",
+  (err) => new NotFoundError({ message: "Not found" }),
+);
 
 // Frontend receives: { _tag: "NotFoundError", message: "Not found" }
 // - Can't show specific message ("User doesn't exist" vs "Channel was deleted")
@@ -145,6 +143,32 @@ export class SessionExpiredError extends Schema.TaggedError<SessionExpiredError>
 2. **Type safety** - `_tag` discriminator enables `catchTag`
 3. **Consistent structure** - All errors have predictable shape
 4. **HTTP status mapping** - Via `HttpApiSchema.annotations`
+5. **Yieldable** - Can be used directly without `Effect.fail` wrapper
+
+### TaggedErrors Are Yieldable
+
+`Schema.TaggedError` instances implement the `Effect` interface, so they can be yielded or returned directly — no `Effect.fail(...)` wrapper needed:
+
+```typescript
+// ✅ CORRECT - TaggedErrors are yieldable
+yield* new UserNotFoundError({ userId: id, message: "Not found" })
+
+// ❌ UNNECESSARY - Effect.fail wrapper is redundant for TaggedErrors
+yield* Effect.fail(new UserNotFoundError({ userId: id, message: "Not found" }))
+
+// Works in catchTag handlers too:
+Effect.catchTag("DatabaseError", (err) =>
+  new UserNotFoundError({ userId: id, message: err.message }),
+)
+
+// And in Option.match:
+Option.match(maybeUser, {
+  onNone: () => new UserNotFoundError({ userId, message: "Not found" }),
+  onSome: Effect.succeed,
+})
+```
+
+> **Note:** Only `Schema.TaggedError` instances are yieldable. Plain `Error` objects still require `Effect.fail()`.
 
 ### Basic Error Definition
 
@@ -206,18 +230,46 @@ Every error should have:
 const findUser = Effect.fn("UserService.findUser")(function* (id: UserId) {
   return yield* repo.findById(id).pipe(
     Effect.catchTag("DatabaseError", (err) =>
-      Effect.fail(
-        new UserNotFoundError({
-          userId: id,
-          message: `Database lookup failed: ${err.message}`,
-        }),
-      ),
+      new UserNotFoundError({
+        userId: id,
+        message: `Database lookup failed: ${err.message}`,
+      }),
     ),
   );
 });
 ```
 
-### catchTags for Multiple Error Types
+### catchTag with Multiple Tags (Same Handler)
+
+`Effect.catchTag` accepts **multiple tag strings** before the handler. When several error types should map to the same handler, pass all tags to a single `catchTag` call instead of using `catchTags` with duplicate handler bodies:
+
+```typescript
+// ✅ CORRECT - multiple tags, single handler via catchTag
+yield* effect.pipe(
+    Effect.catchTag(
+      "TokenExpiredError",
+      "TokenInvalidError",
+      "MissingTokenError",
+      () => new UnauthorizedError({ message: "Authentication failed" }),
+    ),
+  );
+
+// ❌ WRONG - catchTags with duplicate handlers (unnecessary boilerplate)
+yield* effect.pipe(
+    Effect.catchTags({
+      TokenExpiredError: () =>
+        new UnauthorizedError({ message: "Authentication failed" }),
+      TokenInvalidError: () =>
+        new UnauthorizedError({ message: "Authentication failed" }),
+      MissingTokenError: () =>
+        new UnauthorizedError({ message: "Authentication failed" }),
+    }),
+  );
+```
+
+### catchTags for Multiple Error Types (Different Handlers)
+
+Use `catchTags` only when each tag needs a **distinct** handler:
 
 ```typescript
 const processOrder = Effect.fn("OrderService.processOrder")(function* (
@@ -226,26 +278,20 @@ const processOrder = Effect.fn("OrderService.processOrder")(function* (
   return yield* validateAndProcess(input).pipe(
     Effect.catchTags({
       ValidationError: (err) =>
-        Effect.fail(
-          new OrderValidationError({
-            message: err.message,
-            field: err.field,
-          }),
-        ),
+        new OrderValidationError({
+          message: err.message,
+          field: err.field,
+        }),
       PaymentError: (err) =>
-        Effect.fail(
-          new OrderPaymentError({
-            message: `Payment failed: ${err.message}`,
-            code: err.code,
-          }),
-        ),
+        new OrderPaymentError({
+          message: `Payment failed: ${err.message}`,
+          code: err.code,
+        }),
       InventoryError: (err) =>
-        Effect.fail(
-          new OrderInventoryError({
-            productId: err.productId,
-            message: "Insufficient inventory",
-          }),
-        ),
+        new OrderInventoryError({
+          productId: err.productId,
+          message: "Insufficient inventory",
+        }),
     }),
   );
 });
@@ -258,7 +304,7 @@ const processOrder = Effect.fn("OrderService.processOrder")(function* (
 yield *
   effect.pipe(
     Effect.catchAll((err) =>
-      Effect.fail(new InternalServerError({ message: "Something failed" })),
+      new InternalServerError({ message: "Something failed" }),
     ),
   );
 
@@ -282,21 +328,17 @@ export const withRemapDbErrors = <A, E, R>(
 ): Effect.Effect<A, E | EntityNotFoundError | ServiceUnavailableError, R> =>
   effect.pipe(
     Effect.catchTag("DatabaseError", (err) =>
-      Effect.fail(
-        new EntityNotFoundError({
-          entityType: context.entityType,
-          entityId: context.entityId,
-          message: `${context.entityType} not found`,
-        }),
-      ),
+      new EntityNotFoundError({
+        entityType: context.entityType,
+        entityId: context.entityId,
+        message: `${context.entityType} not found`,
+      }),
     ),
     Effect.catchTag("ConnectionError", (err) =>
-      Effect.fail(
-        new ServiceUnavailableError({
-          message: "Database connection unavailable",
-          cause: err.message,
-        }),
-      ),
+      new ServiceUnavailableError({
+        message: "Database connection unavailable",
+        cause: err.message,
+      }),
     ),
   );
 
@@ -448,14 +490,12 @@ export class UnauthorizedError extends Schema.TaggedError<UnauthorizedError>()(
 ) {}
 
 // Then mapping everything to it - loses critical information!
-Effect.catchTags({
-  SessionExpiredError: (err) =>
-    Effect.fail(new UnauthorizedError({ message: "Unauthorized" })),
-  InvalidCredentialsError: (err) =>
-    Effect.fail(new UnauthorizedError({ message: "Unauthorized" })),
-  MissingTokenError: (err) =>
-    Effect.fail(new UnauthorizedError({ message: "Unauthorized" })),
-});
+Effect.catchTag(
+  "SessionExpiredError",
+  "InvalidCredentialsError",
+  "MissingTokenError",
+  (err) => new UnauthorizedError({ message: "Unauthorized" }),
+);
 // Frontend can't distinguish: expired session vs wrong password vs missing token
 ```
 
@@ -477,12 +517,10 @@ export class InternalServerError extends Schema.TaggedError<InternalServerError>
 
 // Use sparingly - only for truly unexpected errors
 Effect.catchAll((unexpectedError) =>
-  Effect.fail(
-    new InternalServerError({
-      message: "An unexpected error occurred",
-      requestId: context.requestId,
-    }),
-  ),
+  new InternalServerError({
+    message: "An unexpected error occurred",
+    requestId: context.requestId,
+  }),
 );
 ```
 

--- a/effect-best-practices/references/layer-patterns.md
+++ b/effect-best-practices/references/layer-patterns.md
@@ -1,5 +1,17 @@
 # Layer Patterns
 
+## Table of Contents
+
+- [Dependencies in Effect.Service](#dependencies-in-effectservice)
+- [Infrastructure Layers](#infrastructure-layers)
+- [Layer.mergeAll Over Nested Provides](#layermergeall-over-nested-provides)
+- [Layer Naming Conventions](#layer-naming-conventions)
+- [Layer.unwrapEffect for Config-Dependent Layers](#layerunwrapeffect-for-config-dependent-layers)
+- [Scoped Layers](#scoped-layers)
+- [Testing Layer Composition](#testing-layer-composition)
+- [Layer.effect vs Layer.succeed](#layereffect-vs-layersucceed)
+- [Lazy Layers](#lazy-layers)
+
 ## Dependencies in Effect.Service
 
 **Critical rule:** Always declare dependencies in the `dependencies` array of `Effect.Service`. This ensures proper composition and avoids "leaked dependencies" that require manual wiring at usage sites.

--- a/effect-best-practices/references/layer-patterns.md
+++ b/effect-best-practices/references/layer-patterns.md
@@ -110,7 +110,7 @@ const AppLive = Layer.mergeAll(
 **Use `Layer.mergeAll`** for composing layers at the same level:
 
 ```typescript
-// CORRECT - Flat composition
+// ✅ CORRECT - Flat composition
 const ServicesLive = Layer.mergeAll(
     UserService.Default,
     OrderService.Default,

--- a/effect-best-practices/references/layer-patterns.md
+++ b/effect-best-practices/references/layer-patterns.md
@@ -223,7 +223,7 @@ export class UserServiceInMemory extends Effect.Service<UserService>()("UserServ
         return {
             findById: Effect.fn("UserService.findById")(function* (id) {
                 const user = store.get(id)
-                if (!user) return yield* Effect.fail(new UserNotFoundError({ userId: id }))
+                if (!user) return yield* new UserNotFoundError({ userId: id })
                 return user
             }),
             create: Effect.fn("UserService.create")(function* (input) {
@@ -270,7 +270,7 @@ const ValidatedConfigLive = Layer.unwrapEffect(
 
         // Validate config
         if (!config.dbUrl.startsWith("postgresql://")) {
-            return yield* Effect.fail(new ConfigError({ message: "Invalid DATABASE_URL" }))
+            return yield* new ConfigError({ message: "Invalid DATABASE_URL" })
         }
 
         return Layer.succeed(AppConfig, config)

--- a/effect-best-practices/references/layer-patterns.md
+++ b/effect-best-practices/references/layer-patterns.md
@@ -2,6 +2,7 @@
 
 ## Table of Contents
 
+- [Layer Structure](#layer-structure)
 - [Dependencies in Effect.Service](#dependencies-in-effectservice)
 - [Infrastructure Layers](#infrastructure-layers)
 - [Layer.mergeAll Over Nested Provides](#layermergeall-over-nested-provides)
@@ -11,6 +12,42 @@
 - [Testing Layer Composition](#testing-layer-composition)
 - [Layer.effect vs Layer.succeed](#layereffect-vs-layersucceed)
 - [Lazy Layers](#lazy-layers)
+- [Merge vs Provide](#merge-vs-provide)
+
+## Layer Structure
+
+Understanding the Layer type signature:
+
+```typescript
+Layer<RequirementsOut, Error, RequirementsIn>
+         ▲                ▲           ▲
+         │                │           └─ What this layer needs
+         │                └─ Errors during construction
+         └─ What this layer produces
+```
+
+Example:
+
+```typescript
+// Layer<Logger, never, Config>
+//         ▲      ▲      ▲
+//         │      │      └─ Needs Config
+//         │      └─ Cannot fail
+//         └─ Produces Logger
+export const LoggerLive = Layer.effect(
+  Logger,
+  Effect.gen(function* () {
+    const config = yield* Config
+    return Logger.of({
+      log: (message) =>
+        Effect.gen(function* () {
+          const { logLevel } = yield* config.getConfig
+          console.log(`[${logLevel}] ${message}`)
+        })
+    })
+  })
+)
+```
 
 ## Dependencies in Effect.Service
 
@@ -142,7 +179,7 @@ const AppLive = ServicesLive.pipe(
 ```
 
 ```typescript
-// WRONG - Deeply nested, hard to read
+// ❌ WRONG - Deeply nested, hard to read
 const AppLive = UserService.Default.pipe(
     Layer.provide(
         OrderService.Default.pipe(
@@ -352,3 +389,91 @@ const ExpensiveServiceLive = Layer.lazy(() => {
     )
 })
 ```
+
+## Merge vs Provide
+
+Understanding when to use `Layer.merge` vs `Layer.provide`:
+
+### Merge (Parallel Composition)
+
+Combine independent layers that don't depend on each other:
+
+```typescript
+// Layer<Config | Logger, never, Config>
+//         ▲               ▲      ▲
+//         │               │      └─ LoggerLive needs Config
+//         │               └─ No errors
+//         └─ Produces both Config and Logger
+const AppConfigLive = Layer.merge(ConfigLive, LoggerLive)
+```
+
+Result combines:
+
+- **Requirements**: Union (`never | Config = Config`)
+- **Outputs**: Union (`Config | Logger`)
+
+### Provide (Sequential Composition)
+
+Chain dependent layers where one satisfies another's requirements:
+
+```typescript
+// Layer<Logger, never, never>
+//         ▲      ▲      ▲
+//         │      │      └─ ConfigLive satisfies LoggerLive's requirement
+//         │      └─ No errors
+//         └─ Only Logger in output
+const FullLoggerLive = Layer.provide(LoggerLive, ConfigLive)
+```
+
+Result:
+
+- **Requirements**: Outer layer's requirements (`never`)
+- **Output**: Inner layer's output (`Logger`)
+
+### ProvideMerge
+
+Chain dependent layers where one satisfies another's requirements, but combine their outputs:
+
+```typescript
+// Layer<Config | Logger, never, never>
+//         ▲               ▲      ▲
+//         │               │      └─ LoggerLive needs Config
+//         │               └─ No errors
+//         └─ Produces both Config and Logger
+const FullLoggerLive = Layer.provideMerge(LoggerLive, ConfigLive)
+```
+
+Result:
+
+- **Requirements**:  `never`
+- **Output**: Union (`Config | Logger`)
+
+### Layered Architecture Example
+
+Build applications in layers:
+
+```typescript
+// Infrastructure: No dependencies
+const InfrastructureLive = Layer.mergeAll(
+  ConfigLive,          // Layer<Config, never, never>
+  DatabaseLive,        // Layer<Database, never, Config>
+  CacheLive            // Layer<Cache, never, Config>
+).pipe(
+  Layer.provide(ConfigLive)  // Satisfy Config requirement
+)
+
+// Domain: Depends on infrastructure
+const DomainLive = Layer.mergeAll(
+  PaymentDomainLive,   // Layer<PaymentDomain, never, Database>
+  OrderDomainLive,     // Layer<OrderDomain, never, Database>
+).pipe(
+  Layer.provide(InfrastructureLive)
+)
+
+// Application: Depends on domain
+const ApplicationLive = Layer.mergeAll(
+  PaymentGatewayLive,
+  NotificationServiceLive
+).pipe(
+  Layer.provide(DomainLive)
+)

--- a/effect-best-practices/references/layer-patterns.md
+++ b/effect-best-practices/references/layer-patterns.md
@@ -76,7 +76,7 @@ const DatabaseLive = PgClient.layer({
     port: Config.integer("DB_PORT"),
     database: Config.string("DB_NAME"),
     username: Config.string("DB_USER"),
-    password: Config.secret("DB_PASSWORD"),
+    password: Config.redacted("DB_PASSWORD"),
 })
 
 // Services use database but don't declare it in dependencies

--- a/effect-best-practices/references/observability-patterns.md
+++ b/effect-best-practices/references/observability-patterns.md
@@ -1,5 +1,15 @@
 # Observability Patterns
 
+## Table of Contents
+
+- [Structured Logging with Effect.log](#structured-logging-with-effectlog)
+- [Effect.fn for Automatic Tracing](#effectfn-for-automatic-tracing)
+- [Span Annotations](#span-annotations)
+- [Metrics](#metrics)
+- [Configuration with Config](#configuration-with-config)
+- [Log Level Configuration](#log-level-configuration)
+- [Combining Observability](#combining-observability)
+
 ## Structured Logging with Effect.log
 
 **Always use Effect.log** instead of console.log. Effect.log provides:

--- a/effect-best-practices/references/observability-patterns.md
+++ b/effect-best-practices/references/observability-patterns.md
@@ -3,6 +3,7 @@
 ## Structured Logging with Effect.log
 
 **Always use Effect.log** instead of console.log. Effect.log provides:
+
 - Structured data
 - Log levels
 - Integration with telemetry systems
@@ -12,43 +13,47 @@
 
 ```typescript
 // Simple message
-yield* Effect.log("Processing started")
+yield * Effect.log("Processing started");
 
 // With structured data
-yield* Effect.log("Processing order", {
+yield *
+  Effect.log("Processing order", {
     orderId,
     userId,
     amount,
     currency,
-})
+  });
 
 // Different log levels
-yield* Effect.logDebug("Cache lookup", { key, hit: true })
-yield* Effect.logInfo("User logged in", { userId })
-yield* Effect.logWarning("Rate limit approaching", { current: 95, limit: 100 })
-yield* Effect.logError("Payment failed", { orderId, reason: error.message })
-yield* Effect.logFatal("Database connection lost")
+yield * Effect.logDebug("Cache lookup", { key, hit: true });
+yield * Effect.logInfo("User logged in", { userId });
+yield *
+  Effect.logWarning("Rate limit approaching", { current: 95, limit: 100 });
+yield * Effect.logError("Payment failed", { orderId, reason: error.message });
+yield * Effect.logFatal("Database connection lost");
 ```
 
 ### Logging in Services
 
 ```typescript
-const processOrder = Effect.fn("OrderService.processOrder")(function* (input: OrderInput) {
-    yield* Effect.log("Starting order processing", { orderId: input.orderId })
+const processOrder = Effect.fn("OrderService.processOrder")(function* (
+  input: OrderInput,
+) {
+  yield* Effect.log("Starting order processing", { orderId: input.orderId });
 
-    const result = yield* validateAndProcess(input).pipe(
-        Effect.tap(() => Effect.log("Order processed successfully")),
-        Effect.tapError((err) =>
-            Effect.logError("Order processing failed", {
-                orderId: input.orderId,
-                error: err._tag,
-                message: err.message,
-            })
-        ),
-    )
+  const result = yield* validateAndProcess(input).pipe(
+    Effect.tap(() => Effect.log("Order processed successfully")),
+    Effect.tapError((err) =>
+      Effect.logError("Order processing failed", {
+        orderId: input.orderId,
+        error: err._tag,
+        message: err.message,
+      }),
+    ),
+  );
 
-    return result
-})
+  return result;
+});
 ```
 
 ## Effect.fn for Automatic Tracing
@@ -58,23 +63,25 @@ const processOrder = Effect.fn("OrderService.processOrder")(function* (input: Or
 ```typescript
 // Creates span: "UserService.findById"
 const findById = Effect.fn("UserService.findById")(function* (id: UserId) {
-    // Automatic span creation with:
-    // - Start/end timing
-    // - Error capture
-    // - Parameter tracking (if annotated)
-})
+  // Automatic span creation with:
+  // - Start/end timing
+  // - Error capture
+  // - Parameter tracking (if annotated)
+});
 
 // Creates span: "PaymentService.processPayment"
-const processPayment = Effect.fn("PaymentService.processPayment")(
-    function* (orderId: OrderId, amount: number) {
-        // ...
-    }
-)
+const processPayment = Effect.fn("PaymentService.processPayment")(function* (
+  orderId: OrderId,
+  amount: number,
+) {
+  // ...
+});
 ```
 
 ### Naming Convention
 
 Use `ServiceName.methodName` format consistently:
+
 - `UserService.findById`
 - `OrderService.create`
 - `PaymentService.refund`
@@ -85,27 +92,31 @@ Use `ServiceName.methodName` format consistently:
 Add important context to spans, but don't overdo it:
 
 ```typescript
-const processOrder = Effect.fn("OrderService.process")(function* (orderId: OrderId) {
-    // GOOD - Important business identifiers
-    yield* Effect.annotateCurrentSpan("orderId", orderId)
-    yield* Effect.annotateCurrentSpan("userId", order.userId)
-    yield* Effect.annotateCurrentSpan("totalAmount", order.total)
+const processOrder = Effect.fn("OrderService.process")(function* (
+  orderId: OrderId,
+) {
+  // GOOD - Important business identifiers
+  yield* Effect.annotateCurrentSpan("orderId", orderId);
+  yield* Effect.annotateCurrentSpan("userId", order.userId);
+  yield* Effect.annotateCurrentSpan("totalAmount", order.total);
 
-    // BAD - Too much detail, creates noise
-    // yield* Effect.annotateCurrentSpan("step", "validating")
-    // yield* Effect.annotateCurrentSpan("itemCount", order.items.length)
-    // yield* Effect.annotateCurrentSpan("item0Name", order.items[0].name)
-})
+  // BAD - Too much detail, creates noise
+  // yield* Effect.annotateCurrentSpan("step", "validating")
+  // yield* Effect.annotateCurrentSpan("itemCount", order.items.length)
+  // yield* Effect.annotateCurrentSpan("item0Name", order.items[0].name)
+});
 ```
 
 ### What to Annotate
 
 **Do annotate:**
+
 - Entity IDs (orderId, userId, etc.)
 - Important business values (amounts, statuses)
 - Error context when failing
 
 **Don't annotate:**
+
 - Step-by-step progress
 - Individual item details
 - Internal implementation state
@@ -116,71 +127,72 @@ const processOrder = Effect.fn("OrderService.process")(function* (orderId: Order
 ### Counter
 
 ```typescript
-import { Metric } from "effect"
+import { Metric } from "effect";
 
 // Define metrics at module level
 const ordersProcessed = Metric.counter("orders_processed", {
-    description: "Total orders processed",
-})
+  description: "Total orders processed",
+});
 
 const ordersFailed = Metric.counter("orders_failed", {
-    description: "Total orders that failed processing",
-})
+  description: "Total orders that failed processing",
+});
 
 // Use in service
-const processOrder = Effect.fn("OrderService.process")(function* (input: OrderInput) {
-    return yield* process(input).pipe(
-        Effect.tap(() => Metric.increment(ordersProcessed)),
-        Effect.tapError(() => Metric.increment(ordersFailed)),
-    )
-})
+const processOrder = Effect.fn("OrderService.process")(function* (
+  input: OrderInput,
+) {
+  return yield* process(input).pipe(
+    Effect.tap(() => Metric.increment(ordersProcessed)),
+    Effect.tapError(() => Metric.increment(ordersFailed)),
+  );
+});
 ```
 
 ### Counter with Tags
 
 ```typescript
 const httpRequests = Metric.counter("http_requests_total", {
-    description: "Total HTTP requests",
-})
+  description: "Total HTTP requests",
+});
 
 // Tag with method and status
-yield* Metric.increment(httpRequests).pipe(
+yield *
+  Metric.increment(httpRequests).pipe(
     Metric.tagged("method", request.method),
     Metric.tagged("status", String(response.status)),
     Metric.tagged("path", request.path),
-)
+  );
 ```
 
 ### Gauge
 
 ```typescript
 const activeConnections = Metric.gauge("active_connections", {
-    description: "Number of active connections",
-})
+  description: "Number of active connections",
+});
 
 // Update gauge
-yield* Metric.set(activeConnections, connectionCount)
+yield * Metric.set(activeConnections, connectionCount);
 
 // Or increment/decrement
-yield* Metric.increment(activeConnections)
-yield* Metric.decrement(activeConnections)
+yield * Metric.increment(activeConnections);
+yield * Metric.decrement(activeConnections);
 ```
 
 ### Histogram
 
 ```typescript
 const requestDuration = Metric.histogram("request_duration_ms", {
-    description: "Request duration in milliseconds",
-    boundaries: [10, 50, 100, 250, 500, 1000, 2500, 5000],
-})
+  description: "Request duration in milliseconds",
+  boundaries: [10, 50, 100, 250, 500, 1000, 2500, 5000],
+});
 
 // Record value
-yield* Metric.update(requestDuration, durationMs)
+yield * Metric.update(requestDuration, durationMs);
 
 // Or use timer helper
-const timedEffect = effect.pipe(
-    Metric.timerWithHistogram(requestDuration),
-)
+const timedEffect = effect.pipe(Metric.timerWithHistogram(requestDuration));
 ```
 
 ## Configuration with Config
@@ -190,43 +202,45 @@ const timedEffect = effect.pipe(
 ### Basic Config
 
 ```typescript
-import { Config, Effect } from "effect"
+import { Config, Effect } from "effect";
 
+// Effects are lazy, they don't execute by default
 const config = Config.all({
-    port: Config.integer("PORT").pipe(Config.withDefault(3000)),
-    host: Config.string("HOST").pipe(Config.withDefault("localhost")),
-    env: Config.literal("development", "staging", "production")("NODE_ENV"),
-})
+  port: Config.integer("PORT").pipe(Config.withDefault(3000)),
+  host: Config.string("HOST").pipe(Config.withDefault("localhost")),
+  env: Config.literal("development", "staging", "production")("NODE_ENV"),
+});
 
 // Use in layer
 const ServerLive = Layer.unwrapEffect(
-    Effect.gen(function* () {
-        const { port, host, env } = yield* config
-        return Layer.succeed(ServerConfig, { port, host, env })
-    })
-)
+  Effect.gen(function* () {
+    // actually execute the effect and read the config
+    const { port, host, env } = yield* config;
+    return Layer.succeed(ServerConfig, { port, host, env });
+  }),
+);
 ```
 
 ### Config with Validation
 
 ```typescript
 const dbConfig = Config.all({
-    host: Config.string("DB_HOST"),
-    port: Config.integer("DB_PORT").pipe(
-        Config.validate({
-            message: "Port must be between 1 and 65535",
-            validation: (p) => p >= 1 && p <= 65535,
-        })
-    ),
-    database: Config.string("DB_NAME"),
-    maxConnections: Config.integer("DB_MAX_CONNECTIONS").pipe(
-        Config.withDefault(10),
-        Config.validate({
-            message: "Max connections must be positive",
-            validation: (n) => n > 0,
-        })
-    ),
-})
+  host: Config.string("DB_HOST"),
+  port: Config.integer("DB_PORT").pipe(
+    Config.validate({
+      message: "Port must be between 1 and 65535",
+      validation: (p) => p >= 1 && p <= 65535,
+    }),
+  ),
+  database: Config.string("DB_NAME"),
+  maxConnections: Config.integer("DB_MAX_CONNECTIONS").pipe(
+    Config.withDefault(10),
+    Config.validate({
+      message: "Max connections must be positive",
+      validation: (n) => n > 0,
+    }),
+  ),
+});
 ```
 
 ### Secret Config
@@ -234,109 +248,116 @@ const dbConfig = Config.all({
 ```typescript
 // For sensitive values that shouldn't be logged
 const secretConfig = Config.all({
-    apiKey: Config.secret("API_KEY"),           // Returns Secret<string>
-    dbPassword: Config.secret("DB_PASSWORD"),
-})
+  apiKey: Config.secret("API_KEY"), // Returns Secret<string>
+  dbPassword: Config.secret("DB_PASSWORD"),
+});
 
 // Using secrets
 const program = Effect.gen(function* () {
-    const { apiKey, dbPassword } = yield* secretConfig
+  const { apiKey, dbPassword } = yield* secretConfig;
 
-    // Secret values are wrapped - use Secret.value to unwrap
-    const key = Secret.value(apiKey)
+  // Secret values are wrapped - use Secret.value to unwrap
+  const key = Secret.value(apiKey);
 
-    // Logging a Secret shows "[REDACTED]"
-    yield* Effect.log("Config loaded", { apiKey }) // Safe - shows [REDACTED]
-})
+  // Logging a Secret shows "[REDACTED]"
+  yield* Effect.log("Config loaded", { apiKey }); // Safe - shows [REDACTED]
+});
 ```
 
 ### Config with Nested Structure
 
 ```typescript
 const appConfig = Config.all({
-    server: Config.all({
-        port: Config.integer("SERVER_PORT"),
-        host: Config.string("SERVER_HOST"),
-    }),
-    database: Config.all({
-        url: Config.string("DATABASE_URL"),
-        pool: Config.integer("DATABASE_POOL_SIZE").pipe(Config.withDefault(10)),
-    }),
-    features: Config.all({
-        enableBeta: Config.boolean("ENABLE_BETA").pipe(Config.withDefault(false)),
-        maxUploadSize: Config.integer("MAX_UPLOAD_SIZE").pipe(Config.withDefault(10485760)),
-    }),
-})
+  server: Config.all({
+    port: Config.integer("SERVER_PORT"),
+    host: Config.string("SERVER_HOST"),
+  }),
+  database: Config.all({
+    url: Config.string("DATABASE_URL"),
+    pool: Config.integer("DATABASE_POOL_SIZE").pipe(Config.withDefault(10)),
+  }),
+  features: Config.all({
+    enableBeta: Config.boolean("ENABLE_BETA").pipe(Config.withDefault(false)),
+    maxUploadSize: Config.integer("MAX_UPLOAD_SIZE").pipe(
+      Config.withDefault(10485760),
+    ),
+  }),
+});
 ```
 
 ## Log Level Configuration
 
 ```typescript
-import { Logger, LogLevel } from "effect"
+import { Logger, LogLevel } from "effect";
 
 // Set log level via config
 const LoggerLive = Layer.unwrapEffect(
-    Effect.gen(function* () {
-        const level = yield* Config.literal(
-            "debug", "info", "warning", "error"
-        )("LOG_LEVEL").pipe(Config.withDefault("info"))
+  Effect.gen(function* () {
+    const level = yield* Config.literal(
+      "debug",
+      "info",
+      "warning",
+      "error",
+    )("LOG_LEVEL").pipe(Config.withDefault("info"));
 
-        const logLevel = {
-            debug: LogLevel.Debug,
-            info: LogLevel.Info,
-            warning: LogLevel.Warning,
-            error: LogLevel.Error,
-        }[level]
+    const logLevel = {
+      debug: LogLevel.Debug,
+      info: LogLevel.Info,
+      warning: LogLevel.Warning,
+      error: LogLevel.Error,
+    }[level];
 
-        return Logger.minimumLogLevel(logLevel)
-    })
-)
+    return Logger.minimumLogLevel(logLevel);
+  }),
+);
 
 // Production: structured JSON logging
-const JsonLoggerLive = Logger.json
+const JsonLoggerLive = Logger.json;
 ```
 
 ## Combining Observability
 
 ```typescript
-const processOrder = Effect.fn("OrderService.process")(function* (input: OrderInput) {
-    const startTime = yield* Effect.clockWith((clock) => clock.currentTimeMillis)
+const processOrder = Effect.fn("OrderService.process")(function* (
+  input: OrderInput,
+) {
+  const startTime = yield* Effect.clockWith((clock) => clock.currentTimeMillis);
 
-    // Annotate span
-    yield* Effect.annotateCurrentSpan("orderId", input.orderId)
-    yield* Effect.annotateCurrentSpan("userId", input.userId)
+  // Annotate span
+  yield* Effect.annotateCurrentSpan("orderId", input.orderId);
+  yield* Effect.annotateCurrentSpan("userId", input.userId);
 
-    // Log start
-    yield* Effect.log("Processing order", { orderId: input.orderId })
+  // Log start
+  yield* Effect.log("Processing order", { orderId: input.orderId });
 
-    const result = yield* process(input).pipe(
-        Effect.tap((order) =>
-            Effect.gen(function* () {
-                const endTime = yield* Effect.clockWith((c) => c.currentTimeMillis)
-                const duration = endTime - startTime
+  const result = yield* process(input).pipe(
+    Effect.tap((order) =>
+      Effect.gen(function* () {
+        const endTime = yield* Effect.clockWith((c) => c.currentTimeMillis);
+        const duration = endTime - startTime;
 
-                // Record metric
-                yield* Metric.update(orderProcessingDuration, duration)
-                yield* Metric.increment(ordersProcessed)
+        // Record metric
+        yield* Metric.update(orderProcessingDuration, duration);
+        yield* Metric.increment(ordersProcessed);
 
-                // Log completion
-                yield* Effect.log("Order processed", {
-                    orderId: input.orderId,
-                    durationMs: duration,
-                })
-            })
-        ),
-        Effect.tapError((err) =>
-            Effect.gen(function* () {
-                yield* Metric.increment(ordersFailed)
-                yield* Effect.logError("Order processing failed", {
-                    orderId: input.orderId,
-                    error: err._tag,
-                })
-            })
-        ),
-    )
+        // Log completion
+        yield* Effect.log("Order processed", {
+          orderId: input.orderId,
+          durationMs: duration,
+        });
+      }),
+    ),
+    Effect.tapError((err) =>
+      Effect.gen(function* () {
+        yield* Metric.increment(ordersFailed);
+        yield* Effect.logError("Order processing failed", {
+          orderId: input.orderId,
+          error: err._tag,
+        });
+      }),
+    ),
+  );
 
-    return result
-})
+  return result;
+});
 ```

--- a/effect-best-practices/references/observability-patterns.md
+++ b/effect-best-practices/references/observability-patterns.md
@@ -248,8 +248,8 @@ const dbConfig = Config.all({
 ```typescript
 // For sensitive values that shouldn't be logged
 const secretConfig = Config.all({
-  apiKey: Config.secret("API_KEY"), // Returns Secret<string>
-  dbPassword: Config.secret("DB_PASSWORD"),
+  apiKey: Config.redacted("API_KEY"), // Returns Secret<string>
+  dbPassword: Config.redacted("DB_PASSWORD"),
 });
 
 // Using secrets

--- a/effect-best-practices/references/rpc-cluster-patterns.md
+++ b/effect-best-practices/references/rpc-cluster-patterns.md
@@ -251,7 +251,7 @@ export const OrderFulfillmentWorkflowLayer = OrderFulfillmentWorkflow.toLayer(
 **Always include `success` and `error` schemas** in Activity.make:
 
 ```typescript
-// CORRECT - schemas specified
+// ✅ CORRECT - schemas specified
 yield* Activity.make({
     name: "SendEmail",
     success: EmailSentResult,

--- a/effect-best-practices/references/rpc-cluster-patterns.md
+++ b/effect-best-practices/references/rpc-cluster-patterns.md
@@ -1,5 +1,16 @@
 # RPC & Cluster Patterns
 
+## Table of Contents
+
+- [RpcGroup for API Organization](#rpcgroup-for-api-organization)
+- [Error Unions in RPC](#error-unions-in-rpc)
+- [RPC Middleware for Authentication](#rpc-middleware-for-authentication)
+- [Workflow Definition](#workflow-definition)
+- [Activity Patterns](#activity-patterns)
+- [ClusterCron for Scheduled Jobs](#clustercron-for-scheduled-jobs)
+- [Triggering Workflows](#triggering-workflows)
+- [Workflow HTTP API](#workflow-http-api)
+
 ## RpcGroup for API Organization
 
 **Use `RpcGroup.make`** to organize related RPC endpoints:

--- a/effect-best-practices/references/rpc-cluster-patterns.md
+++ b/effect-best-practices/references/rpc-cluster-patterns.md
@@ -137,15 +137,12 @@ export const AuthMiddlewareLive = Layer.effect(
                     const token = request.headers.get("authorization")?.replace("Bearer ", "")
 
                     if (!token) {
-                        return yield* Effect.fail(new UnauthorizedError({ message: "Missing token" }))
+                        return yield* new UnauthorizedError({ message: "Missing token" })
                     }
 
                     const user = yield* authService.validateToken(token).pipe(
-                        Effect.catchTag("TokenExpiredError", () =>
-                            Effect.fail(new UnauthorizedError({ message: "Token expired" }))
-                        ),
-                        Effect.catchTag("TokenInvalidError", () =>
-                            Effect.fail(new UnauthorizedError({ message: "Invalid token" }))
+                        Effect.catchTag("TokenExpiredError", "TokenInvalidError", () =>
+                            new UnauthorizedError({ message: "Invalid or expired token" })
                         ),
                     )
 
@@ -309,7 +306,7 @@ yield* Activity.make({
     execute: Effect.gen(function* () {
         const response = yield* fetch(url)
         if (!response.ok) {
-            return yield* Effect.fail(ExternalApiError.fromResponse(response))
+            return yield* ExternalApiError.fromResponse(response)
         }
         return yield* response.json()
     }),
@@ -420,7 +417,7 @@ const executeWorkflowHandler = Effect.gen(function* () {
 
     const workflow = client.workflows[name]
     if (!workflow) {
-        return yield* Effect.fail(new WorkflowNotFoundError({ name }))
+        return yield* new WorkflowNotFoundError({ name })
     }
 
     const result = yield* workflow.execute(payload)

--- a/effect-best-practices/references/schema-patterns.md
+++ b/effect-best-practices/references/schema-patterns.md
@@ -264,7 +264,7 @@ export const PaymentMethod = Schema.Union(
 
 // Discriminated union (tagged)
 export const PaymentDetails = Schema.Union(
-  Schema.TaggedStruct({
+  Schema.TaggedStruct("Card", {
     cardNumber: Schema.String,
     expiry: Schema.String,
     cvv: Schema.String,

--- a/effect-best-practices/references/schema-patterns.md
+++ b/effect-best-practices/references/schema-patterns.md
@@ -1,5 +1,19 @@
 # Schema Patterns
 
+## Table of Contents
+
+- [Branded Types for IDs](#branded-types-for-ids)
+- [Schema.Struct for Domain Types](#schemastruct-for-domain-types)
+- [Schema.transform and transformOrFail](#schematransform-and-transformorfail)
+- [Schema.Class for Entities with Methods](#schemaclass-for-entities-with-methods)
+- [Schema.annotations](#schemaannotations)
+- [Optional Fields](#optional-fields)
+- [Union Types and Discriminated Unions](#union-types-and-discriminated-unions)
+- [Enums and Literals](#enums-and-literals)
+- [Recursive Schemas](#recursive-schemas)
+- [Decoding and Encoding](#decoding-and-encoding)
+- [JSON Encoding & Decoding](#json-encoding--decoding)
+
 ## Branded Types for IDs
 
 **Always brand entity IDs** to prevent accidentally passing the wrong ID type:

--- a/effect-best-practices/references/schema-patterns.md
+++ b/effect-best-practices/references/schema-patterns.md
@@ -5,25 +5,26 @@
 **Always brand entity IDs** to prevent accidentally passing the wrong ID type:
 
 ```typescript
-import { Schema } from "effect"
+import { Schema } from "effect";
 
 // Entity IDs - always branded with namespace
-export const UserId = Schema.UUID.pipe(Schema.brand("@App/UserId"))
-export type UserId = Schema.Schema.Type<typeof UserId>
+export const UserId = Schema.UUID.pipe(Schema.brand("@App/UserId"));
+export type UserId = Schema.Schema.Type<typeof UserId>;
 
-export const OrganizationId = Schema.UUID.pipe(Schema.brand("@App/OrganizationId"))
-export type OrganizationId = Schema.Schema.Type<typeof OrganizationId>
+export const OrganizationId = Schema.UUID.pipe(Schema.brand("@App/OrganizationId"));
+export type OrganizationId = Schema.Schema.Type<typeof OrganizationId>;
 
-export const OrderId = Schema.UUID.pipe(Schema.brand("@App/OrderId"))
-export type OrderId = Schema.Schema.Type<typeof OrderId>
+export const OrderId = Schema.UUID.pipe(Schema.brand("@App/OrderId"));
+export type OrderId = Schema.Schema.Type<typeof OrderId>;
 
-export const ProductId = Schema.UUID.pipe(Schema.brand("@App/ProductId"))
-export type ProductId = Schema.Schema.Type<typeof ProductId>
+export const ProductId = Schema.UUID.pipe(Schema.brand("@App/ProductId"));
+export type ProductId = Schema.Schema.Type<typeof ProductId>;
 ```
 
 ### Branding Convention
 
 Use `@Namespace/EntityName` format:
+
 - `@App/UserId` - Main application entities
 - `@Billing/InvoiceId` - Billing domain entities
 - `@External/StripeCustomerId` - External system IDs
@@ -32,13 +33,15 @@ Use `@Namespace/EntityName` format:
 
 ```typescript
 // From string (validates UUID format)
-const userId = Schema.decodeSync(UserId)("123e4567-e89b-12d3-a456-426614174000")
+const userId = Schema.decodeSync(UserId)(
+  "123e4567-e89b-12d3-a456-426614174000",
+);
 
 // Generate new ID
-const newUserId = UserId.make(crypto.randomUUID())
+const newUserId = UserId.make(crypto.randomUUID());
 
 // Type error - can't mix ID types
-const order = yield* orderService.findById(userId) // Error: UserId is not OrderId
+const order = yield * orderService.findById(userId); // Error: UserId is not OrderId
 ```
 
 ### When NOT to Brand
@@ -47,9 +50,8 @@ Don't brand simple strings that don't need type safety:
 
 ```typescript
 // NOT branded - acceptable
-export const Url = Schema.String
-export const FilePath = Schema.String
-export const EmailAddress = Schema.String.pipe(Schema.pattern(/^[^\s@]+@[^\s@]+\.[^\s@]+$/))
+export const Url = Schema.String;
+export const FilePath = Schema.String;
 
 // These don't need branding because:
 // 1. They don't cross service boundaries in ways that could be confused
@@ -61,47 +63,43 @@ export const EmailAddress = Schema.String.pipe(Schema.pattern(/^[^\s@]+@[^\s@]+\
 **Prefer Schema.Struct** over TypeScript interfaces for domain types:
 
 ```typescript
-// CORRECT - Schema.Struct
+// ✅ CORRECT - Schema.Struct
 export const User = Schema.Struct({
-    id: UserId,
-    email: Schema.String,
-    name: Schema.String,
-    organizationId: OrganizationId,
-    role: Schema.Literal("admin", "member", "viewer"),
-    createdAt: Schema.DateTimeUtc,
-    updatedAt: Schema.DateTimeUtc,
-})
-export type User = Schema.Schema.Type<typeof User>
+  id: UserId,
+  email: Schema.String,
+  name: Schema.String,
+  organizationId: OrganizationId,
+  role: Schema.Literal("admin", "member", "viewer"),
+  createdAt: Schema.DateTimeUtc,
+  updatedAt: Schema.DateTimeUtc,
+});
+export type User = Schema.Schema.Type<typeof User>;
 
 // Can derive encoded type for database/API
-export type UserEncoded = Schema.Schema.Encoded<typeof User>
+export type UserEncoded = Schema.Schema.Encoded<typeof User>;
 ```
 
 ### Input Types for Mutations
 
 ```typescript
 export const CreateUserInput = Schema.Struct({
-    email: Schema.String.pipe(
-        Schema.pattern(/^[^\s@]+@[^\s@]+\.[^\s@]+$/),
-        Schema.annotations({ description: "Valid email address" }),
-    ),
-    name: Schema.String.pipe(
-        Schema.minLength(1),
-        Schema.maxLength(100),
-    ),
-    organizationId: OrganizationId,
-    role: Schema.optionalWith(
-        Schema.Literal("admin", "member", "viewer"),
-        { default: () => "member" as const }
-    ),
-})
-export type CreateUserInput = Schema.Schema.Type<typeof CreateUserInput>
+  email: Schema.String.pipe(
+    Schema.pattern(/^[^\s@]+@[^\s@]+\.[^\s@]+$/),
+    Schema.annotations({ description: "Valid email address" }),
+  ),
+  name: Schema.String.pipe(Schema.minLength(1), Schema.maxLength(100)),
+  organizationId: OrganizationId,
+  role: Schema.optionalWith(Schema.Literal("admin", "member", "viewer"), {
+    default: () => "member" as const,
+  }),
+});
+export type CreateUserInput = Schema.Schema.Type<typeof CreateUserInput>;
 
 export const UpdateUserInput = Schema.Struct({
-    name: Schema.optional(Schema.String.pipe(Schema.minLength(1))),
-    role: Schema.optional(Schema.Literal("admin", "member", "viewer")),
-})
-export type UpdateUserInput = Schema.Schema.Type<typeof UpdateUserInput>
+  name: Schema.optional(Schema.String.pipe(Schema.minLength(1))),
+  role: Schema.optional(Schema.Literal("admin", "member", "viewer")),
+});
+export type UpdateUserInput = Schema.Schema.Type<typeof UpdateUserInput>;
 ```
 
 ## Schema.transform and transformOrFail
@@ -111,61 +109,54 @@ export type UpdateUserInput = Schema.Schema.Type<typeof UpdateUserInput>
 ```typescript
 // Transform string to Date
 export const DateFromString = Schema.transform(
-    Schema.String,
-    Schema.DateTimeUtc,
-    {
-        decode: (s) => new Date(s),
-        encode: (d) => d.toISOString(),
-    }
-)
+  Schema.String,
+  Schema.DateTimeUtc,
+  {
+    decode: (s) => new Date(s),
+    encode: (d) => d.toISOString(),
+  },
+);
 
 // Transform with validation (can fail)
 export const PositiveNumber = Schema.transformOrFail(
-    Schema.Number,
-    Schema.Number.pipe(Schema.brand("PositiveNumber")),
-    {
-        decode: (n, _, ast) =>
-            n > 0
-                ? ParseResult.succeed(n as Schema.Schema.Type<typeof PositiveNumber>)
-                : ParseResult.fail(new ParseResult.Type(ast, n, "Must be positive")),
-        encode: ParseResult.succeed,
-    }
-)
+  Schema.Number,
+  Schema.Number.pipe(Schema.brand("PositiveNumber")),
+  {
+    decode: (n, _, ast) =>
+      n > 0
+        ? ParseResult.succeed(n as Schema.Schema.Type<typeof PositiveNumber>)
+        : ParseResult.fail(new ParseResult.Type(ast, n, "Must be positive")),
+    encode: ParseResult.succeed,
+  },
+);
 ```
 
 ### Common Transforms
 
 ```typescript
-// JSON string to object
-export const JsonFromString = <A, I>(schema: Schema.Schema<A, I>) =>
-    Schema.transform(
-        Schema.String,
-        schema,
-        {
-            decode: (s) => JSON.parse(s),
-            encode: (a) => JSON.stringify(a),
-        }
-    )
-
 // Comma-separated string to array
 export const CommaSeparatedList = Schema.transform(
-    Schema.String,
-    Schema.Array(Schema.String),
-    {
-        decode: (s) => s.split(",").map((x) => x.trim()).filter(Boolean),
-        encode: (arr) => arr.join(","),
-    }
-)
+  Schema.String,
+  Schema.Array(Schema.String),
+  {
+    decode: (s) =>
+      s
+        .split(",")
+        .map((x) => x.trim())
+        .filter(Boolean),
+    encode: (arr) => arr.join(","),
+  },
+);
 
 // Cents to dollars
 export const DollarsFromCents = Schema.transform(
-    Schema.Number.pipe(Schema.int()),
-    Schema.Number,
-    {
-        decode: (cents) => cents / 100,
-        encode: (dollars) => Math.round(dollars * 100),
-    }
-)
+  Schema.Number.pipe(Schema.int()),
+  Schema.Number,
+  {
+    decode: (cents) => cents / 100,
+    encode: (dollars) => Math.round(dollars * 100),
+  },
+);
 ```
 
 ## Schema.Class for Entities with Methods
@@ -174,37 +165,37 @@ Use `Schema.Class` when entities need methods:
 
 ```typescript
 export class User extends Schema.Class<User>("User")({
-    id: UserId,
-    email: Schema.String,
-    name: Schema.String,
-    role: Schema.Literal("admin", "member", "viewer"),
-    createdAt: Schema.DateTimeUtc,
+  id: UserId,
+  email: Schema.String,
+  name: Schema.String,
+  role: Schema.Literal("admin", "member", "viewer"),
+  createdAt: Schema.DateTimeUtc,
 }) {
-    get isAdmin(): boolean {
-        return this.role === "admin"
-    }
+  get isAdmin(): boolean {
+    return this.role === "admin";
+  }
 
-    get displayName(): string {
-        return this.name || this.email.split("@")[0]
-    }
+  get displayName(): string {
+    return this.name || this.email.split("@")[0];
+  }
 
-    canAccessResource(resource: Resource): boolean {
-        if (this.isAdmin) return true
-        return resource.ownerId === this.id
-    }
+  canAccessResource(resource: Resource): boolean {
+    if (this.isAdmin) return true;
+    return resource.ownerId === this.id;
+  }
 }
 
 // Usage
 const user = new User({
-    id: UserId.make(crypto.randomUUID()),
-    email: "alice@example.com",
-    name: "Alice",
-    role: "member",
-    createdAt: new Date(),
-})
+  id: UserId.make(crypto.randomUUID()),
+  email: "alice@example.com",
+  name: "Alice",
+  role: "member",
+  createdAt: new Date(),
+});
 
-console.log(user.displayName) // "Alice"
-console.log(user.isAdmin) // false
+console.log(user.displayName); // "Alice"
+console.log(user.isAdmin); // false
 ```
 
 ## Schema.annotations
@@ -213,30 +204,32 @@ Add annotations for documentation and validation messages:
 
 ```typescript
 export const CreateOrderInput = Schema.Struct({
-    productId: ProductId.pipe(
-        Schema.annotations({ description: "The product to order" }),
-    ),
-    quantity: Schema.Number.pipe(
-        Schema.int(),
-        Schema.positive(),
-        Schema.annotations({
-            description: "Number of items to order",
-            examples: [1, 5, 10],
-        }),
-    ),
-    shippingAddress: Schema.Struct({
-        line1: Schema.String.pipe(Schema.annotations({ description: "Street address" })),
-        line2: Schema.optional(Schema.String),
-        city: Schema.String,
-        state: Schema.String.pipe(Schema.length(2)),
-        zip: Schema.String.pipe(Schema.pattern(/^\d{5}(-\d{4})?$/)),
-    }).pipe(Schema.annotations({ description: "Shipping destination" })),
-}).pipe(
+  productId: ProductId.pipe(
+    Schema.annotations({ description: "The product to order" }),
+  ),
+  quantity: Schema.Number.pipe(
+    Schema.int(),
+    Schema.positive(),
     Schema.annotations({
-        title: "Create Order Input",
-        description: "Input for creating a new order",
+      description: "Number of items to order",
+      examples: [1, 5, 10],
     }),
-)
+  ),
+  shippingAddress: Schema.Struct({
+    line1: Schema.String.pipe(
+      Schema.annotations({ description: "Street address" }),
+    ),
+    line2: Schema.optional(Schema.String),
+    city: Schema.String,
+    state: Schema.String.pipe(Schema.length(2)),
+    zip: Schema.String.pipe(Schema.pattern(/^\d{5}(-\d{4})?$/)),
+  }).pipe(Schema.annotations({ description: "Shipping destination" })),
+}).pipe(
+  Schema.annotations({
+    title: "Create Order Input",
+    description: "Input for creating a new order",
+  }),
+);
 ```
 
 ## Optional Fields
@@ -245,18 +238,18 @@ Use `Schema.optional` and `Schema.optionalWith`:
 
 ```typescript
 export const UserPreferences = Schema.Struct({
-    // Optional, undefined if not provided
-    theme: Schema.optional(Schema.Literal("light", "dark")),
+  // Optional, undefined if not provided
+  theme: Schema.optional(Schema.Literal("light", "dark")),
 
-    // Optional with default value
-    language: Schema.optionalWith(Schema.String, { default: () => "en" }),
+  // Optional with default value
+  language: Schema.optionalWith(Schema.String, { default: () => "en" }),
 
-    // Optional with null support (for database compatibility)
-    bio: Schema.NullOr(Schema.String),
+  // Optional with null support (for database compatibility)
+  bio: Schema.NullOr(Schema.String),
 
-    // Optional but must be present if set (no undefined)
-    timezone: Schema.optional(Schema.String, { exact: true }),
-})
+  // Optional but must be present if set (no undefined)
+  timezone: Schema.optional(Schema.String, { exact: true }),
+});
 ```
 
 ## Union Types and Discriminated Unions
@@ -264,90 +257,123 @@ export const UserPreferences = Schema.Struct({
 ```typescript
 // Simple union
 export const PaymentMethod = Schema.Union(
-    Schema.Literal("card"),
-    Schema.Literal("bank_transfer"),
-    Schema.Literal("crypto"),
-)
+  Schema.Literal("card"),
+  Schema.Literal("bank_transfer"),
+  Schema.Literal("crypto"),
+);
 
 // Discriminated union (tagged)
 export const PaymentDetails = Schema.Union(
-    Schema.Struct({
-        _tag: Schema.Literal("Card"),
-        cardNumber: Schema.String,
-        expiry: Schema.String,
-        cvv: Schema.String,
-    }),
-    Schema.Struct({
-        _tag: Schema.Literal("BankTransfer"),
-        accountNumber: Schema.String,
-        routingNumber: Schema.String,
-    }),
-    Schema.Struct({
-        _tag: Schema.Literal("Crypto"),
-        walletAddress: Schema.String,
-        network: Schema.Literal("ethereum", "bitcoin", "solana"),
-    }),
-)
-export type PaymentDetails = Schema.Schema.Type<typeof PaymentDetails>
+  Schema.TaggedStruct({
+    cardNumber: Schema.String,
+    expiry: Schema.String,
+    cvv: Schema.String,
+  }),
+  Schema.TaggedStruct("BankTransfer", {
+    accountNumber: Schema.String,
+    routingNumber: Schema.String,
+  }),
+  Schema.TaggedStruct("Crypto", {
+    walletAddress: Schema.String,
+    network: Schema.Literal("ethereum", "bitcoin", "solana"),
+  }),
+);
+export type PaymentDetails = Schema.Schema.Type<typeof PaymentDetails>;
 
-// Usage with match
-const processPayment = (details: PaymentDetails) => {
-    switch (details._tag) {
-        case "Card":
-            return processCard(details.cardNumber, details.expiry, details.cvv)
-        case "BankTransfer":
-            return processBankTransfer(details.accountNumber, details.routingNumber)
-        case "Crypto":
-            return processCrypto(details.walletAddress, details.network)
-    }
-}
+// Usage with Match.valueTags
+const processPayment = (details: PaymentDetails) =>
+  Match.valueTags(details, {
+    Card: ({ cardNumber, expiry, cvv }) => processCard(cardNumber, expiry, cvv),
+    BankTransfer: ({ accountNumber, routingNumber }) => processBankTransfer(accountNumber, routingNumber),
+    Crypto: ({ walletAddress, network }) => processCrypto(walletAddress, network),
+  });
 ```
 
 ## Enums and Literals
 
 ```typescript
 // Use Literal for small, fixed sets
-export const UserRole = Schema.Literal("admin", "member", "viewer")
-export type UserRole = Schema.Schema.Type<typeof UserRole>
+export const UserRole = Schema.Literal("admin", "member", "viewer");
+export type UserRole = Schema.Schema.Type<typeof UserRole>;
 
 // Use Enums for larger sets or when you need runtime values
 export const OrderStatus = Schema.Enums({
-    Pending: "pending",
-    Processing: "processing",
-    Shipped: "shipped",
-    Delivered: "delivered",
-    Cancelled: "cancelled",
-} as const)
-export type OrderStatus = Schema.Schema.Type<typeof OrderStatus>
+  Pending: "pending",
+  Processing: "processing",
+  Shipped: "shipped",
+  Delivered: "delivered",
+  Cancelled: "cancelled",
+} as const);
+export type OrderStatus = Schema.Schema.Type<typeof OrderStatus>;
 ```
 
 ## Recursive Schemas
 
 ```typescript
 interface Category {
-    id: string
-    name: string
-    children: readonly Category[]
+  id: string;
+  name: string;
+  children: readonly Category[];
 }
 
 export const Category: Schema.Schema<Category> = Schema.Struct({
-    id: Schema.String,
-    name: Schema.String,
-    children: Schema.Array(Schema.suspend(() => Category)),
-})
+  id: Schema.String,
+  name: Schema.String,
+  children: Schema.Array(Schema.suspend(() => Category)),
+});
 ```
 
 ## Decoding and Encoding
 
 ```typescript
 // Decode (parse) - use in services
-const parseUser = Schema.decodeUnknown(User)
-const result = yield* parseUser(rawData) // Effect<User, ParseError>
+const parseUser = Schema.decodeUnknown(User);
+const result = yield * parseUser(rawData); // Effect<User, ParseError>
 
 // Decode sync - only in controlled contexts
-const user = Schema.decodeUnknownSync(User)(rawData)
+const user = Schema.decodeUnknownSync(User)(rawData);
 
 // Encode - for serialization
-const encodeUser = Schema.encode(User)
-const encoded = yield* encodeUser(user) // Effect<UserEncoded, ParseError>
+const encodeUser = Schema.encode(User);
+const encoded = yield * encodeUser(user); // Effect<UserEncoded, ParseError>
+```
+
+## JSON Encoding & Decoding
+
+Use `Schema.parseJson` to parse JSON strings and validate them with your schema in one step. This combines `JSON.parse` + `Schema.decodeUnknown` for decoding, and `JSON.stringify` + `Schema.encode` for encoding:
+
+```ts
+import { Effect, Schema } from "effect";
+
+const Row = Schema.Literal("A", "B", "C", "D", "E", "F", "G", "H");
+const Column = Schema.Literal("1", "2", "3", "4", "5", "6", "7", "8");
+
+class Position extends Schema.Class<Position>("Position")({
+  row: Row,
+  column: Column,
+}) {}
+
+class Move extends Schema.Class<Move>("Move")({
+  from: Position,
+  to: Position,
+}) {}
+
+// parseJson combines JSON.parse + schema decoding
+// MoveFromJson is a schema that takes a JSON string and returns a Move
+const MoveFromJson = Schema.parseJson(Move);
+
+const program = Effect.gen(function* () {
+  // Parse and validate JSON string in one step
+  // Use MoveFromJson (not Move) to decode from JSON string
+  const jsonString =
+    '{"from":{"row":"A","column":"1"},"to":{"row":"B","column":"2"}}';
+  const move = yield* Schema.decodeUnknown(MoveFromJson)(jsonString);
+
+  yield* Effect.log("Decoded move", move);
+
+  // Encode to JSON string in one step (typed as string)
+  // Use MoveFromJson (not Move) to encode to JSON string
+  const json = yield* Schema.encode(MoveFromJson)(move);
+  return json;
+});
 ```

--- a/effect-best-practices/references/service-patterns.md
+++ b/effect-best-practices/references/service-patterns.md
@@ -77,10 +77,10 @@ export class OrderService extends Effect.Service<OrderService>()("OrderService",
             const available = yield* inventory.checkAvailability(input.productId, input.quantity)
 
             if (!available) {
-                return yield* Effect.fail(new InsufficientInventoryError({
+                return yield* new InsufficientInventoryError({
                     productId: input.productId,
                     message: "Not enough inventory",
-                }))
+                })
             }
 
             // Create order...
@@ -397,7 +397,7 @@ const findById = Effect.fn("UserService.findById")(
     function* (id: UserId): Effect.Effect<User, UserNotFoundError> {
         const maybeUser = yield* repo.findById(id)
         return yield* Option.match(maybeUser, {
-            onNone: () => Effect.fail(new UserNotFoundError({ userId: id, message: "Not found" })),
+            onNone: () => new UserNotFoundError({ userId: id, message: "Not found" }),
             onSome: Effect.succeed,
         })
     }
@@ -432,7 +432,7 @@ export class UserServiceTest extends Effect.Service<UserService>()("UserService"
 
         const findById = Effect.fn("UserService.findById")(function* (id: UserId) {
             const user = users.get(id)
-            if (!user) return yield* Effect.fail(new UserNotFoundError({ userId: id, message: "Not found" }))
+            if (!user) return yield* new UserNotFoundError({ userId: id, message: "Not found" })
             return user
         })
 

--- a/effect-best-practices/references/service-patterns.md
+++ b/effect-best-practices/references/service-patterns.md
@@ -125,7 +125,7 @@ const processPayment = Effect.fn("PaymentService.processPayment")(
 Add important context to spans, but don't overdo it:
 
 ```typescript
-// CORRECT - Important business identifiers
+// ✅ CORRECT - Important business identifiers
 yield* Effect.annotateCurrentSpan("userId", userId)
 yield* Effect.annotateCurrentSpan("orderId", orderId)
 yield* Effect.annotateCurrentSpan("amount", amount)
@@ -194,7 +194,7 @@ const DatabaseLive = PgClient.layer({
 Each service should have a focused responsibility:
 
 ```typescript
-// CORRECT - Focused services
+// ✅ CORRECT - Focused services
 export class UserService extends Effect.Service<UserService>()("UserService", { /* user operations */ }) {}
 export class AuthService extends Effect.Service<AuthService>()("AuthService", { /* auth operations */ }) {}
 export class NotificationService extends Effect.Service<NotificationService>()("NotificationService", { /* notifications */ }) {}
@@ -223,7 +223,7 @@ export class AppService extends Effect.Service<AppService>()("AppService", {
 Services should return `Effect` types, never `Promise`:
 
 ```typescript
-// CORRECT
+// ✅ CORRECT
 const findById = Effect.fn("UserService.findById")(
     function* (id: UserId): Effect.Effect<User, UserNotFoundError> {
         // ...
@@ -239,7 +239,7 @@ const findById = async (id: UserId): Promise<User> => {
 ### Use Option for Nullable Results
 
 ```typescript
-// CORRECT - findById can fail, findByIdOption returns Option
+// ✅ CORRECT - findById can fail, findByIdOption returns Option
 const findById = Effect.fn("UserService.findById")(
     function* (id: UserId): Effect.Effect<User, UserNotFoundError> {
         const maybeUser = yield* repo.findById(id)

--- a/effect-best-practices/references/service-patterns.md
+++ b/effect-best-practices/references/service-patterns.md
@@ -6,6 +6,9 @@
 - [Effect.fn for Tracing](#effectfn-for-tracing)
 - [When Context.Tag is Acceptable](#when-contexttag-is-acceptable)
 - [Single Responsibility](#single-responsibility)
+- [Capability-Based Services](#capability-based-services)
+- [No Requirement Leakage in Service Interface](#no-requirement-leakage-in-service-interface)
+- [Optional Capabilities](#optional-capabilities)
 - [Service Interface Patterns](#service-interface-patterns)
 - [Testing Services](#testing-services)
 
@@ -46,6 +49,7 @@ export class UserService extends Effect.Service<UserService>()("UserService", {
 ### Service with Dependencies
 
 **Critical:** Always declare dependencies using the `dependencies` array. This ensures:
+
 - Dependencies are automatically provided when using `ServiceName.Default`
 - Type errors if dependencies are missing
 - No manual `Layer.provide` at usage sites
@@ -150,7 +154,7 @@ yield* Effect.annotateCurrentSpan("step", "completing")
 
 ## When Context.Tag is Acceptable
 
-`Context.Tag` is appropriate **only** for infrastructure that's injected at runtime:
+`Context.Tag` is appropriate for infrastructure that's injected at runtime:
 
 ### Cloudflare Worker Bindings
 
@@ -223,6 +227,146 @@ export class AppService extends Effect.Service<AppService>()("AppService", {
         }
     }),
 }) {}
+```
+
+## Capability-Based Services
+
+Design services as focused capabilities that compose into complete solutions:
+
+```typescript
+// ❌ WRONG - Mixed concerns in one service
+export class PaymentService extends Context.Tag("PaymentService")<
+  PaymentService,
+  {
+    readonly processPayment: ...
+    readonly validateWebhook: ...
+    readonly refund: ...
+    readonly sendReceipt: ...       // Notification concern
+    readonly generateReport: ...    // Reporting concern
+  }
+>() {}
+
+// ✅ CORRECT - Focused capabilities
+export class PaymentGateway extends Context.Tag(
+  "@services/payment/PaymentGateway"
+)<
+  PaymentGateway,
+  {
+    readonly handoff: (
+      intent: Doc<"paymentIntents">
+    ) => Effect.Effect<HandoffResult, HandoffError, never>
+  }
+>() {}
+
+export class PaymentWebhookGateway extends Context.Tag(
+  "@services/payment/PaymentWebhookGateway"
+)<
+  PaymentWebhookGateway,
+  {
+    readonly validateWebhook: (
+      payload: WebhookPayload
+    ) => Effect.Effect<void, WebhookValidationError, never>
+  }
+>() {}
+
+export class PaymentRefundGateway extends Context.Tag(
+  "@services/payment/PaymentRefundGateway"
+)<
+  PaymentRefundGateway,
+  {
+    readonly refund: (
+      paymentId: PaymentId,
+      amount: Cents
+    ) => Effect.Effect<RefundResult, RefundError, never>
+  }
+>() {}
+```
+
+### Composing Capabilities
+
+Different implementations support different capabilities:
+
+```typescript
+// Cash payments: Basic handoff only
+export const CashGatewayLive = Layer.succeed(
+  PaymentGateway,
+  PaymentGateway.of({
+    handoff: (intent) => fulfillCashPayment(intent)
+  })
+)
+
+// Stripe: Full capability suite
+export const StripeGatewayLive = Layer.mergeAll(
+  StripeHandoffLive,      // Implements PaymentGateway
+  StripeWebhookLive,      // Implements PaymentWebhookGateway
+  StripeRefundLive        // Implements PaymentRefundGateway
+)
+```
+
+## No Requirement Leakage in Service Interface
+
+Service operations should not have requirements in their return type:
+
+```typescript
+// The service interface stays clean
+export class Database extends Context.Tag("Database")<
+  Database,
+  {
+    readonly query: (
+      sql: string
+    ) => Effect.Effect<QueryResult, QueryError, never>
+    //                                             ▲
+    //                                  Requirements = never
+  }
+>() {}
+```
+
+There are certain exceptions to this rule:
+
+- Runtime dependencies (e.g. Cloudflare Bindings, Http Request details)
+- Dependencies that need to be different on each method call (e.g. AI providers depending on availability)
+
+Dependencies are handled during **layer construction**, not in the service interface:
+
+```typescript
+// Dependencies live in the layer
+export const DatabaseLive = Layer.effect(
+  Database,
+  Effect.gen(function* () {
+    const config = yield* Config    // Dependency
+    const logger = yield* Logger    // Dependency
+
+    return Database.of({
+      query: (sql) =>
+        Effect.gen(function* () {
+          yield* logger.log(`Executing: ${sql}`)
+          const { connection } = yield* config.getConfig
+          return executeQuery(connection, sql)
+        })
+    })
+  })
+)
+```
+
+## Optional Capabilities
+
+Use `Effect.serviceOption` for capabilities that may not be available:
+
+```typescript
+const processPayment = (order: Order) =>
+  Effect.gen(function* () {
+    const handoff = yield* PaymentGateway
+    const result = yield* handoff.handoff(order.paymentIntent)
+
+    // Optional capability - check if available
+    const refundGateway = yield* Effect.serviceOption(PaymentRefundGateway)
+
+    if (Option.isSome(refundGateway)) {
+      yield* setupRefundPolicy(refundGateway.value, order)
+    }
+
+    return result
+  })
 ```
 
 ## Service Interface Patterns

--- a/effect-best-practices/references/service-patterns.md
+++ b/effect-best-practices/references/service-patterns.md
@@ -1,5 +1,14 @@
 # Service Patterns
 
+## Table of Contents
+
+- [Effect.Service Over Context.Tag](#effectservice-over-contexttag)
+- [Effect.fn for Tracing](#effectfn-for-tracing)
+- [When Context.Tag is Acceptable](#when-contexttag-is-acceptable)
+- [Single Responsibility](#single-responsibility)
+- [Service Interface Patterns](#service-interface-patterns)
+- [Testing Services](#testing-services)
+
 ## Effect.Service Over Context.Tag
 
 **Always prefer `Effect.Service`** for defining business logic services. This is the modern, recommended approach that provides:


### PR DESCRIPTION
## Summary

- **Remove redundant `Effect.fail()` wrappers**: `Schema.TaggedError` instances are yieldable (they implement the `Effect` interface), so `Effect.fail(new SomeError(...))` is replaced with just `new SomeError(...)` across all examples in 6 files
- **Document multi-tag `catchTag`**: `Effect.catchTag` accepts variadic tag strings (`catchTag("A", "B", "C", handler)`) for mapping multiple errors to a single handler, eliminating the need for `catchTags` with duplicate handler bodies
- **Add "TaggedErrors Are Yieldable" section** in `error-patterns.md` with clear ✅/❌ examples and a note that plain `Error` objects still require `Effect.fail()`

## Test plan
- [ ] Verify all code examples are syntactically correct
- [ ] Confirm `GenericError` in FORBIDDEN examples still uses `Effect.fail()` (not a TaggedError)
- [ ] Review multi-tag `catchTag` examples match current Effect API